### PR TITLE
Improved logging and resolved fixed version and disk usage bug

### DIFF
--- a/src/export/Dockerfile
+++ b/src/export/Dockerfile
@@ -4,12 +4,13 @@ MAINTAINER Lukas Martinelli <me@lukasmartinelli.ch>
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-RUN npm install -g tl \
-	   mbtiles \
-           tilelive-tmsource \
-           tilelive-vector \
-	   tilelive-bridge \
-	   tilelive-mapnik
+RUN npm install -g tl@0.4.0 \
+          mapnik@3.4.9 \
+          mbtiles@0.8.2 \
+          tilelive-tmsource@0.4.2 \
+          tilelive-vector@3.5.1 \
+          tilelive-bridge@2.2.1 \
+          tilelive-mapnik@0.6.17
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         python \

--- a/src/export/export.py
+++ b/src/export/export.py
@@ -60,7 +60,6 @@ def create_tilelive_command(tm2source, mbtiles_file, bbox,
 
 
 def export_local(tilelive_command, logging_info):
-    start = time.time()
     proc = subprocess.Popen(
         tilelive_command,
         stdout=subprocess.PIPE,
@@ -72,14 +71,15 @@ def export_local(tilelive_command, logging_info):
     regex = re.compile(r'^Mapnik LOG> \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}: ',
                        re.IGNORECASE)
 
+    for line in iter(proc.stderr.readline, ''):
+        sanitized_line = regex.sub('Mapnik: ', line.rstrip())
+        mapnik_logger.warning(sanitized_line, extra=logging_info)
+
     for line in iter(proc.stdout.readline, ''):
         sanitized_line = regex.sub('Mapnik: ', line.rstrip())
-        mapnik_logger.info(sanitized_line, extra=logging_info)
+        mapnik_logger.debug(sanitized_line, extra=logging_info)
 
     proc.wait()
-    end = time.time()
-    export_logger.info('Elapsed time: {}'.format(end - start),
-                       extra=logging_info)
 
     if proc.returncode != 0:
         raise subprocess.CalledProcessError(returncode=proc.returncode,
@@ -127,9 +127,15 @@ def export_remote(tm2source, sqs_queue, render_scheme, bucket_name):
             render_scheme
         )
 
+        start = time.time()
         export_local(tilelive_command, logging_info)
+        end = time.time()
+        delta = (end - start).total_seconds()
+
+        export_logger.info('Elapsed time: {}'.format(delta),
+                           extra=logging_info)
         upload_mbtiles(bucket, mbtiles_file)
-        export_logger.info("Upload mbtiles {}".format(mbtiles_file),
+        export_logger.info('Upload mbtiles {}'.format(mbtiles_file),
                            extra=logging_info)
 
         queue.delete_message(message)
@@ -173,8 +179,9 @@ def main(args):
     if args.get('remote'):
         formatter = logging.Formatter('%(ip)s %(task_id)s %(message)s')
         handler = watchtower.CloudWatchLogHandler()
-        handler .setFormatter(formatter)
+        handler.setFormatter(formatter)
 
+        mapnik_logger.setLevel(logging.WARNING)
         mapnik_logger.addHandler(handler)
         export_logger.addHandler(handler)
 

--- a/src/export/export.py
+++ b/src/export/export.py
@@ -71,13 +71,9 @@ def export_local(tilelive_command, logging_info):
     regex = re.compile(r'^Mapnik LOG> \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}: ',
                        re.IGNORECASE)
 
-    for line in iter(proc.stderr.readline, ''):
-        sanitized_line = regex.sub('Mapnik: ', line.rstrip())
-        mapnik_logger.warning(sanitized_line, extra=logging_info)
-
     for line in iter(proc.stdout.readline, ''):
         sanitized_line = regex.sub('Mapnik: ', line.rstrip())
-        mapnik_logger.debug(sanitized_line, extra=logging_info)
+        mapnik_logger.warning(sanitized_line, extra=logging_info)
 
     proc.wait()
 
@@ -130,9 +126,8 @@ def export_remote(tm2source, sqs_queue, render_scheme, bucket_name):
         start = time.time()
         export_local(tilelive_command, logging_info)
         end = time.time()
-        delta = (end - start).total_seconds()
 
-        export_logger.info('Elapsed time: {}'.format(delta),
+        export_logger.info('Elapsed time: {}'.format(int(end - start)),
                            extra=logging_info)
         upload_mbtiles(bucket, mbtiles_file)
         export_logger.info('Upload mbtiles {}'.format(mbtiles_file),
@@ -181,7 +176,6 @@ def main(args):
         handler = watchtower.CloudWatchLogHandler()
         handler.setFormatter(formatter)
 
-        mapnik_logger.setLevel(logging.WARNING)
         mapnik_logger.addHandler(handler)
         export_logger.addHandler(handler)
 

--- a/src/export/export.py
+++ b/src/export/export.py
@@ -114,6 +114,7 @@ def export_remote(tm2source, sqs_queue, render_scheme, bucket_name):
         export_logger.info('Elapsed time: {}'.format(int(end - start)),
                            extra=logging_info)
         upload_mbtiles(bucket, mbtiles_file)
+        os.remove(mbtiles_file)
         export_logger.info('Upload mbtiles {}'.format(mbtiles_file),
                            extra=logging_info)
 


### PR DESCRIPTION
- NPM Package versions inside Docker container are now pinned to distinct versions - to ensure build always works and does not install unexpected versions (this caused a bug while building images on one machine)
- Use `check_output` instead of the more low-level `Popen` to catch more error information and better logging at the cost of having less realtime output. If the process fails the entire output is captured and sent to AWS CloudWatch logging
- Measure time only if successful and measure time in seconds not fractions of seconds
- And most **important fix**: Clean up after yourself - created MBTiles should be deleted afterwards otherwise disk will slowly fill up