### PR TITLE
Use tile cover to calculate dirty tiles

### DIFF
--- a/src/detect-dirty-tiles/coveredTiles.js
+++ b/src/detect-dirty-tiles/coveredTiles.js
@@ -1,0 +1,16 @@
+var cover = require('tile-cover');
+
+module.exports = function(geometry, minZoomLevel, maxZoomLevel) {
+    var limits = {
+        min_zoom: minZoomLevel,
+        max_zoom:maxZoomLevel
+    };
+
+    return cover.tiles(geometry, limits).map(function(tile) {
+        return {
+            x: tile[0],
+            y: tile[1],
+            z: tile[2]
+        };
+    });
+};

--- a/src/detect-dirty-tiles/index.js
+++ b/src/detect-dirty-tiles/index.js
@@ -2,6 +2,7 @@ var _ = require('underscore');
 var q = require('q');
 var fs = require('fs');
 var path = require('path');
+var coveredTiles = require('./coveredTiles.js');
 
 var pgp = require('pg-promise')({
     promiseLib: q
@@ -17,93 +18,113 @@ var db = pgp({
 var exportDir = process.env.EXPORT_DIR || '/data/export/';
 var dirtyTilesListFile = process.env.LIST_FILE || path.join(exportDir, 'tiles.txt');
 
+function queryChanges(timestamp, viewName) {
+    return db.query(
+        'SELECT osm_id, ST_AsGeoJSON(ST_Transform(geometry, 4326)) AS geometry ' +
+        'FROM ' + viewName + ' ' +
+        'WHERE timestamp=$1', [timestamp]
+    ).then(function(rows) {
+        return rows.map(function(row) {
+            return {
+                osmId: row.osm_id,
+                geometry: JSON.parse(row.geometry)
+            };
+        });
+    });
+}
+
+function affectedTiles(timestamp, viewName, minZoomLevel, maxZoomLevel) {
+    return queryChanges(timestamp, viewName).then(function(rows) {
+        return rows.map(function(row) {
+            return {
+                view: viewName,
+                osmId: row.osmId,
+                affectedTiles: coveredTiles(row.geometry, minZoomLevel, maxZoomLevel)
+            };
+        });
+    });
+}
+
 function recentDirtyViews() {
-    return db.task(function (t) {
-            t.one('SELECT MAX(timestamp) FROM osm_timestamps')
-                .then(function (result) {
-                    return t.batch([
-                        detectDirtyTiles('landuse_z5', 5, 5),
-                        detectDirtyTiles('landuse_z6', 6, 6),
-                        detectDirtyTiles('landuse_z7', 7, 7),
-                        detectDirtyTiles('landuse_z8', 8, 8),
-                        detectDirtyTiles('landuse_z9', 9, 9),
-                        detectDirtyTiles('landuse_z10', 10, 10),
-                        detectDirtyTiles('landuse_z11', 11, 11),
-                        detectDirtyTiles('landuse_z12', 12, 12),
-                        detectDirtyTiles('landuse_z13toz14', 13, 14),
-                        detectDirtyTiles('waterway_z8toz12', 8, 12),
-                        detectDirtyTiles('waterway_z13toz14', 13, 14),
-                        detectDirtyTiles('water_z6toz12', 6, 12),
-                        detectDirtyTiles('water_z13toz14', 13, 14),
-                        detectDirtyTiles('aeroway_z12toz14', 12, 14),
-                        detectDirtyTiles('barrier_line_z14', 14, 14),
-                        detectDirtyTiles('landuse_overlay_z7', 7, 7),
-                        detectDirtyTiles('landuse_overlay_z8', 8, 8),
-                        detectDirtyTiles('landuse_overlay_z9', 9, 9),
-                        detectDirtyTiles('landuse_overlay_z10', 10, 10),
-                        detectDirtyTiles('landuse_overlay_z11toz12', 11, 12),
-                        detectDirtyTiles('landuse_overlay_z13toz14', 13, 14),
-                        detectDirtyTiles('tunnel_z12toz14', 12, 14),
-                        detectDirtyTiles('road_z5to6', 5, 6),
-                        detectDirtyTiles('road_z7', 7, 7),
-                        detectDirtyTiles('road_z8to10', 8, 10),
-                        detectDirtyTiles('road_z11', 11, 11),
-                        detectDirtyTiles('road_z12', 12, 12),
-                        detectDirtyTiles('road_z13', 13, 13),
-                        detectDirtyTiles('road_z14', 14, 14),
-                        detectDirtyTiles('bridge_z12to14', 12, 14),
-                        detectDirtyTiles('admin_z2to6', 2, 6),
-                        detectDirtyTiles('admin_z7to14', 7, 14),
-                        detectDirtyTiles('place_label_z4toz5', 4, 5),
-                        detectDirtyTiles('place_label_z6', 6, 6),
-                        detectDirtyTiles('place_label_z7', 7, 7),
-                        detectDirtyTiles('place_label_z8', 8, 8),
-                        detectDirtyTiles('place_label_z9toz10', 9, 10),
-                        detectDirtyTiles('place_label_z11toz12', 11, 12),
-                        detectDirtyTiles('place_label_z13', 13, 13),
-                        detectDirtyTiles('place_label_z14', 14, 14),
-                        detectDirtyTiles('water_label_z10', 10, 10),
-                        detectDirtyTiles('water_label_z11', 11, 11),
-                        detectDirtyTiles('water_label_z12', 12, 12),
-                        detectDirtyTiles('water_label_z13', 13, 13),
-                        detectDirtyTiles('water_label_z14', 14, 14),
-                        detectDirtyTiles('poi_label_z14', 14, 14),
-                        detectDirtyTiles('road_label_z8toz10', 8, 10),
-                        detectDirtyTiles('road_label_z11', 11, 11),
-                        detectDirtyTiles('road_label_z12toz13', 12, 13),
-                        detectDirtyTiles('road_label_z14', 14, 14),
-                        detectDirtyTiles('waterway_label_z8toz12', 8, 12),
-                        detectDirtyTiles('waterway_label_z13toz14', 13, 14)
-                    ]);
+        return db.one('SELECT MAX(timestamp) FROM osm_timestamps')
+            .then(function (result) {
+                var timestamp = result.max;
 
-                    function detectDirtyTiles(viewName, minZoomLevel, maxZoomLevel) {
-                        return t.any('SELECT * FROM detect_dirty_tiles($1, $2) WHERE z BETWEEN $3 AND $4',
-                            [viewName, result.max, minZoomLevel, maxZoomLevel])
-                            .then(function (rows) {
-                                return {
-                                    viewName: viewName,
-                                    dirtyTiles: rows
-                                };
-                            });
-                    }
+                function detectDirtyTiles(viewName, minZoomLevel, maxZoomLevel) {
+                    return affectedTiles(timestamp, viewName, minZoomLevel, maxZoomLevel);
+                }
 
-                });
-        })
-        .then(_.flatten);
+                return q.all([
+                    detectDirtyTiles('landuse_z5', 5, 5),
+                    detectDirtyTiles('landuse_z6', 6, 6),
+                    detectDirtyTiles('landuse_z7', 7, 7),
+                    detectDirtyTiles('landuse_z8', 8, 8),
+                    detectDirtyTiles('landuse_z9', 9, 9),
+                    detectDirtyTiles('landuse_z10', 10, 10),
+                    detectDirtyTiles('landuse_z11', 11, 11),
+                    detectDirtyTiles('landuse_z12', 12, 12),
+                    detectDirtyTiles('landuse_z13toz14', 13, 14),
+                    detectDirtyTiles('waterway_z8toz12', 8, 12),
+                    detectDirtyTiles('waterway_z13toz14', 13, 14),
+                    detectDirtyTiles('water_z6toz12', 6, 12),
+                    detectDirtyTiles('water_z13toz14', 13, 14),
+                    detectDirtyTiles('aeroway_z12toz14', 12, 14),
+                    detectDirtyTiles('barrier_line_z14', 14, 14),
+                    detectDirtyTiles('landuse_overlay_z7', 7, 7),
+                    detectDirtyTiles('landuse_overlay_z8', 8, 8),
+                    detectDirtyTiles('landuse_overlay_z9', 9, 9),
+                    detectDirtyTiles('landuse_overlay_z10', 10, 10),
+                    detectDirtyTiles('landuse_overlay_z11toz12', 11, 12),
+                    detectDirtyTiles('landuse_overlay_z13toz14', 13, 14),
+                    detectDirtyTiles('tunnel_z12toz14', 12, 14),
+                    detectDirtyTiles('road_z5to6', 5, 6),
+                    detectDirtyTiles('road_z7', 7, 7),
+                    detectDirtyTiles('road_z8to10', 8, 10),
+                    detectDirtyTiles('road_z11', 11, 11),
+                    detectDirtyTiles('road_z12', 12, 12),
+                    detectDirtyTiles('road_z13', 13, 13),
+                    detectDirtyTiles('road_z14', 14, 14),
+                    detectDirtyTiles('bridge_z12to14', 12, 14),
+                    detectDirtyTiles('admin_z2to6', 2, 6),
+                    detectDirtyTiles('admin_z7to14', 7, 14),
+                    detectDirtyTiles('place_label_z4toz5', 4, 5),
+                    detectDirtyTiles('place_label_z6', 6, 6),
+                    detectDirtyTiles('place_label_z7', 7, 7),
+                    detectDirtyTiles('place_label_z8', 8, 8),
+                    detectDirtyTiles('place_label_z9toz10', 9, 10),
+                    detectDirtyTiles('place_label_z11toz12', 11, 12),
+                    detectDirtyTiles('place_label_z13', 13, 13),
+                    detectDirtyTiles('place_label_z14', 14, 14),
+                    detectDirtyTiles('water_label_z10', 10, 10),
+                    detectDirtyTiles('water_label_z11', 11, 11),
+                    detectDirtyTiles('water_label_z12', 12, 12),
+                    detectDirtyTiles('water_label_z13', 13, 13),
+                    detectDirtyTiles('water_label_z14', 14, 14),
+                    detectDirtyTiles('poi_label_z14', 14, 14),
+                    detectDirtyTiles('road_label_z8toz10', 8, 10),
+                    detectDirtyTiles('road_label_z11', 11, 11),
+                    detectDirtyTiles('road_label_z12toz13', 12, 13),
+                    detectDirtyTiles('road_label_z14', 14, 14),
+                    detectDirtyTiles('waterway_label_z8toz12', 8, 12),
+                    detectDirtyTiles('waterway_label_z13toz14', 13, 14)
+                ]);
+
+            }).then(_.flatten);
 }
 
 recentDirtyViews().then(function (dirtyViews) {
-    var tileList = _.flatten(
+    var timeLabel = "Time to calculate dirty tiles";
+    console.time(timeLabel);
+    var tileList = _.uniq(_.flatten(
         dirtyViews.map(function (view) {
-            return view.dirtyTiles;
+            return view.affectedTiles;
         })
     ).map(function (tile) {
         return tile.z + '/' + tile.x + '/' + tile.y;
-    }).join('\n');
-
+    })).join('\n');
+    
+    console.timeEnd(timeLabel);
     console.log('Write dirty tiles to ' + dirtyTilesListFile);
-    console.log(tileList);
-
     fs.writeFileSync(dirtyTilesListFile, tileList, {
         encoding: 'utf8'
     });

--- a/src/detect-dirty-tiles/package.json
+++ b/src/detect-dirty-tiles/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "q": "^1.4.1",
     "underscore": "^1.8.3",
-    "pg-promise": "^3.2.2"
+    "pg-promise": "^3.2.2",
+    "tile-cover": "^3.0.1"
   },
   "devDependencies": {
     "eslint": "^2.2.0",


### PR DESCRIPTION
Doing the dirty tile calculation on the client side (like the initial proof of concept) is up to 500 times faster  (for z12) than using PostgreSQL to do the same with the recursive function.
It also gives back the same results (we compared the `tiles.txt`).

Would never have suspected this but even if we optimize the PostgreSQL like crazy (like by avoiding recursion by storing the tiles into a table and join it). I don't think we can come close to the speed we have with tilecover now.

The performance increase is due to the different approaches.
With tilecover we just calculate the tiles for the dirty shapes
while in PostgreSQL in the essence we check for each tile whether the shape touches the tile (the `geometry && CDB_XYZ_Extent` part of the query).