### PR TITLE
Merge results back into planet MBTiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: all
 
-all: postgis export-mbtiles import-osm import-external import-sql update-scaleranks create-extracts changed-tiles generate-jobs
+all: postgis export-mbtiles import-osm import-external import-sql update-scaleranks create-extracts changed-tiles generate-jobs merge-jobs
 
-fast: postgis export-mbtiles import-osm import-sql update-scaleranks create-extracts changed-tiles generate-jobs
+fast: postgis export-mbtiles import-osm import-sql update-scaleranks create-extracts changed-tiles generate-jobs merge-jobs
 
 postgis:
 	docker build -t osm2vectortiles/postgis src/postgis
@@ -30,3 +30,6 @@ changed-tiles:
 
 generate-jobs:
 	docker build -t osm2vectortiles/generate-jobs src/generate-jobs
+
+merge-jobs:
+	docker build -t osm2vectortiles/merge-jobs src/merge-jobs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,13 @@ generate-jobs:
   image: "osm2vectortiles/generate-jobs"
   volumes:
    - ./export:/data/export
+merge-jobs:
+  image: "osm2vectortiles/merge-jobs"
+  volumes:
+   - ./export:/data/export
+  links:
+   - rabbitmq:rabbitmq
+   - mock-s3:mock-s3
 export-worker:
   image: "osm2vectortiles/export"
   command: ./export-worker.sh

--- a/src/export/export_remote.py
+++ b/src/export/export_remote.py
@@ -22,6 +22,7 @@ import sys
 import os
 import os.path
 import json
+import humanize
 
 from boto.s3.connection import S3Connection, OrdinaryCallingFormat
 import pika
@@ -56,7 +57,7 @@ def upload_mbtiles(bucket, mbtiles_file):
     """Upload mbtiles file to a bucket with the filename as S3 key"""
     keyname = os.path.basename(mbtiles_file)
     obj = bucket.new_key(keyname)
-    obj.set_contents_from_filename(mbtiles_file)
+    obj.set_contents_from_filename(mbtiles_file, replace=True)
 
 
 def create_tilelive_bbox(bounds):
@@ -140,7 +141,7 @@ def export_remote(tm2source, rabbitmq_url, queue_name, result_queue_name,
         subprocess.check_call(tilelive_cmd)
         end = time.time()
 
-        print('Elapsed time: {}'.format(int(end - start)))
+        print('Rendering time: {}'.format(humanize.naturaltime(end - start)))
 
         upload_mbtiles(bucket, mbtiles_file)
         os.remove(mbtiles_file)

--- a/src/export/requirements.txt
+++ b/src/export/requirements.txt
@@ -2,3 +2,4 @@ docopt==0.6.2
 boto==2.38.0
 watchtower==0.1.3
 pika==0.10.0
+humanize==0.5.1

--- a/src/merge-jobs/Dockerfile
+++ b/src/merge-jobs/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.4
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      sqlite3 \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /usr/src/app
+CMD ["./merge-jobs.sh"]

--- a/src/merge-jobs/merge-jobs.py
+++ b/src/merge-jobs/merge-jobs.py
@@ -62,7 +62,7 @@ def merge_results(rabbitmq_url, merge_target, result_queue_name):
             cursor.close()
 
         new_target_size = os.path.getsize(merge_target)
-        diff_size = old_target_size - new_target_size
+        diff_size = new_target_size - old_target_size
         print("Merge {} from {} into {}".format(
             humanize.naturalsize(diff_size),
             merge_source,

--- a/src/merge-jobs/merge-jobs.py
+++ b/src/merge-jobs/merge-jobs.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+"""Download and merge MBTiles back together.
+
+Usage:
+  merge-jobs.py <rabbitmq_url>  --merge-target=<mbtiles-file> [--result-queue=<result-queue>]
+  merge-jobs.py (-h | --help)
+  merge-jobs.py --version
+
+Options:
+  -h --help                      Show this screen.
+  --version                      Show version.
+  --merge-target=<mbtiles-file>  MBTiles file to merge job results into.
+  --result-queue=<result-queue>  Result queue name [default: results]
+"""
+import os
+import os.path
+import json
+import sqlite3
+import pika
+import humanize
+from urllib.request import urlretrieve
+from docopt import docopt
+
+
+def merge_results(rabbitmq_url, merge_target, result_queue_name):
+    if not os.path.isfile(merge_target):
+        raise ValueError('File {} does not exist'.format(merge_target))
+
+    connection = pika.BlockingConnection(pika.URLParameters(rabbitmq_url))
+    channel = connection.channel()
+
+    def callback(ch, method, properties, body):
+        msg = json.loads(body.decode('utf-8'))
+        task_id = msg['id']
+        download_url = msg['url']
+        merge_source = os.path.basename(download_url)
+
+        urlretrieve (download_url, merge_source)
+
+        merge_source_size = os.path.getsize(merge_source)
+        if not os.path.isfile(merge_source):
+            raise ValueError('File {} does not exist'.format(merge_source))
+
+        print('Download {} ({})'.format(
+            download_url,
+            humanize.naturalsize(merge_source_size))
+        )
+        
+        old_target_size = os.path.getsize(merge_target)
+
+        with sqlite3.connect(merge_target) as conn:
+            cursor = conn.cursor()
+            cursor.executescript("""
+                PRAGMA journal_mode=PERSIST;
+                PRAGMA page_size=80000;
+                PRAGMA synchronous=OFF;
+                ATTACH DATABASE '{0}' AS source;
+                REPLACE INTO map SELECT * FROM source.map;
+                REPLACE INTO images SELECT * FROM source.images;
+            """.format(merge_source))
+            conn.commit()
+            cursor.close()
+
+        new_target_size = os.path.getsize(merge_target)
+        diff_size = old_target_size - new_target_size
+        print("Merge {} from {} into {}".format(
+            humanize.naturalsize(diff_size),
+            merge_source,
+            merge_target
+        ))
+
+        os.remove(merge_source)
+        ch.basic_ack(delivery_tag=method.delivery_tag)
+
+    channel.basic_consume(callback, queue=result_queue_name)
+    try:
+        channel.start_consuming()
+    except KeyboardInterrupt:
+        channel.stop_consuming()
+
+    connection.close()
+
+
+def main(args):
+    merge_results(
+        args['<rabbitmq_url>'],
+        args['--merge-target'],
+        args['--result-queue']
+    )
+
+
+if __name__ == '__main__':
+    args = docopt(__doc__, version='0.1')
+    main(args)

--- a/src/merge-jobs/merge-jobs.sh
+++ b/src/merge-jobs/merge-jobs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+set -o nounset
+
+readonly EXPORT_DIR=${EXPORT_DIR:-/data/export}
+readonly MERGE_TARGET=${MERGE_TARGET:-"$EXPORT_DIR/planet.mbtiles"}
+readonly RABBITMQ_URI=${RABBITMQ_URI:-"amqp://osm:osm@rabbitmq:5672/"}
+
+function export_remote_mbtiles() {
+    exec python merge-jobs.py "$RABBITMQ_URI" \
+        --merge-target="$MERGE_TARGET"
+}
+
+export_remote_mbtiles

--- a/src/merge-jobs/requirements.txt
+++ b/src/merge-jobs/requirements.txt
@@ -1,0 +1,3 @@
+docopt==0.6.2
+pika==0.10.0
+humanize==0.5.1


### PR DESCRIPTION
Resolves #207.

The `merge-jobs.py` utility can be given a merge target and the message queue endpoint and it will
keep the merge target up to data. Also wrote a Docker container with wrapper script to integrate it with our docker-compose.