### PR TITLE
Single place label table

### DIFF
--- a/osm2vectortiles.tm2source/data.yml
+++ b/osm2vectortiles.tm2source/data.yml
@@ -670,20 +670,26 @@ Layer:
                               population DESC NULLS LAST
         ) AS localrank
         FROM (
-            SELECT * FROM place_label_z4toz5
-            WHERE z(!scale_denominator!) BETWEEN 4 AND 5
+            SELECT * FROM place_label_z3
+            WHERE z(!scale_denominator!) = 3
             UNION ALL
-            SELECT * FROM place_label_z6
-            WHERE z(!scale_denominator!) = 6
+            SELECT * FROM place_label_z4
+            WHERE z(!scale_denominator!) = 4
             UNION ALL
-            SELECT * FROM place_label_z7
-            WHERE z(!scale_denominator!) = 7
+            SELECT * FROM place_label_z5
+            WHERE z(!scale_denominator!) = 5
+            UNION ALL
+            SELECT * FROM place_label_z6toz7
+            WHERE z(!scale_denominator!) BETWEEN 6 AND 7
             UNION ALL
             SELECT * FROM place_label_z8
             WHERE z(!scale_denominator!) = 8
             UNION ALL
-            SELECT * FROM place_label_z9toz10
-            WHERE z(!scale_denominator!) BETWEEN 9 AND 10
+            SELECT * FROM place_label_z9
+            WHERE z(!scale_denominator!) = 9
+            UNION ALL
+            SELECT * FROM place_label_z10
+            WHERE z(!scale_denominator!) = 10
             UNION ALL
             SELECT * FROM place_label_z11toz12
             WHERE z(!scale_denominator!) BETWEEN 11 AND 12

--- a/src/import-osm/mapping.yml
+++ b/src/import-osm/mapping.yml
@@ -446,22 +446,22 @@ tables:
     type_mappings:
       point:
         place:
-          city
-          town
-          village
-          hamlet
-          suburb
-          neighbourhood
-          isolated_dwelling
+        - city
+        - town
+        - village
+        - hamlet
+        - suburb
+        - neighbourhood
+        - isolated_dwelling
       polygons:
         place:
-          island
-          islet
-          archipelago
+        - island
+        - islet
+        - archipelago
         landuse:
-          residential
+        - residential
         boundary:
-          aboriginal_lands
+        - aboriginal_lands
   road_geometry:
     type: geometry
     fields:

--- a/src/import-osm/mapping.yml
+++ b/src/import-osm/mapping.yml
@@ -395,8 +395,8 @@ tables:
       - zoo
       - camp_site
     type: polygon
-  place_point:
-    type: point
+  place_geometry:
+    type: geometry
     fields:
     - name: osm_id
       type: id
@@ -443,22 +443,25 @@ tables:
       name: scalerank
       type: integer
     mapping:
-      place:
-      - city
-      - town
-      - village
-      - hamlet
-      - suburb
-      - neighbourhood
-      - island
-      - islet
-      - archipelago
-      - region
-      - county
-      - district
-      - municipality
-      - locality
-      - isolated_dwelling
+    type_mappings:
+      point:
+        place:
+          city
+          town
+          village
+          hamlet
+          suburb
+          neighbourhood
+          isolated_dwelling
+      polygons:
+        place:
+          island
+          islet
+          archipelago
+        landuse:
+          residential
+        boundary:
+          aboriginal_lands
   road_geometry:
     type: geometry
     fields:

--- a/src/import-osm/mapping.yml
+++ b/src/import-osm/mapping.yml
@@ -395,8 +395,8 @@ tables:
       - zoo
       - camp_site
     type: polygon
-  place_geometry:
-    type: geometry
+  place_point:
+    type: point
     fields:
     - name: osm_id
       type: id
@@ -442,49 +442,23 @@ tables:
     - key: scalerank
       name: scalerank
       type: integer
-    type_mappings:
-      point:
-        place:
-        - city
-        - town
-        - village
-        - hamlet
-        - suburb
-        - neighbourhood
-        - island
-        - islet
-        - archipelago
-        - region
-        - county
-        - district
-        - municipality
-        - locality
-        - isolated_dwelling
-        landuse:
-        - residential
-        boundary:
-        - aboriginal_lands
-      polygons:
-        place:
-        - city
-        - town
-        - village
-        - hamlet
-        - suburb
-        - neighbourhood
-        - island
-        - islet
-        - archipelago
-        - region
-        - county
-        - district
-        - municipality
-        - locality
-        - isolated_dwelling
-        landuse:
-        - residential
-        boundary:
-        - aboriginal_lands
+    mapping:
+      place:
+      - city
+      - town
+      - village
+      - hamlet
+      - suburb
+      - neighbourhood
+      - island
+      - islet
+      - archipelago
+      - region
+      - county
+      - district
+      - municipality
+      - locality
+      - isolated_dwelling
   road_geometry:
     type: geometry
     fields:

--- a/src/import-osm/mapping.yml
+++ b/src/import-osm/mapping.yml
@@ -444,7 +444,7 @@ tables:
       type: integer
     mapping:
     type_mappings:
-      point:
+      points:
         place:
         - city
         - town

--- a/src/import-osm/mapping.yml
+++ b/src/import-osm/mapping.yml
@@ -443,7 +443,7 @@ tables:
       name: scalerank
       type: integer
     type_mappings:
-      linestrings:
+      point:
         place:
         - city
         - town

--- a/src/import-osm/mapping.yml
+++ b/src/import-osm/mapping.yml
@@ -395,7 +395,8 @@ tables:
       - zoo
       - camp_site
     type: polygon
-  place_point:
+  place_geometry:
+    type: geometry
     fields:
     - name: osm_id
       type: id
@@ -441,96 +442,49 @@ tables:
     - key: scalerank
       name: scalerank
       type: integer
-    mapping:
-      place:
-      - city
-      - town
-      - village
-      - hamlet
-      - suburb
-      - neighbourhood
-      - island
-      - islet
-      - archipelago
-      - region
-      - county
-      - district
-      - municipality
-      - locality
-      - isolated_dwelling
-      landuse:
-      - residential
-      boundary:
-      - aboriginal_lands
-    type: point
-  place_polygon:
-    fields:
-    - name: osm_id
-      type: id
-    - name: geometry
-      type: geometry
-    - name: timestamp
-      type: pbf_timestamp
-    - key: name
-      name: name
-      type: string
-    - name: name_int
-      key: int_name
-      type: string
-    - name: name_fr
-      key: name:fr
-      type: string
-    - name: name_en
-      key: name:en
-      type: string
-    - name: name_de
-      key: name:de
-      type: string
-    - name: name_es
-      key: name:es
-      type: string
-    - name: name_ru
-      key: name:ru
-      type: string
-    - name: name_zh
-      key: name:zh
-      type: string
-    - name: type
-      type: mapping_value
-    - key: population
-      name: population
-      type: integer
-    - key: capital
-      name: capital
-      type: integer
-    - key: admin_level
-      name: admin_level
-      type: integer
-    - key: scalerank
-      name: scalerank
-      type: integer
-    mapping:
-      place:
-      - city
-      - town
-      - village
-      - hamlet
-      - suburb
-      - neighbourhood
-      - island
-      - islet
-      - archipelago
-      - region
-      - county
-      - district
-      - municipality
-      - locality
-      - isolated_dwelling
-      landuse:
-      - residential
-      boundary:
-      - aboriginal_lands
-    type: polygon
+    type_mappings:
+      linestrings:
+        place:
+        - city
+        - town
+        - village
+        - hamlet
+        - suburb
+        - neighbourhood
+        - island
+        - islet
+        - archipelago
+        - region
+        - county
+        - district
+        - municipality
+        - locality
+        - isolated_dwelling
+        landuse:
+        - residential
+        boundary:
+        - aboriginal_lands
+      polygons:
+        place:
+        - city
+        - town
+        - village
+        - hamlet
+        - suburb
+        - neighbourhood
+        - island
+        - islet
+        - archipelago
+        - region
+        - county
+        - district
+        - municipality
+        - locality
+        - isolated_dwelling
+        landuse:
+        - residential
+        boundary:
+        - aboriginal_lands
   road_geometry:
     type: geometry
     fields:

--- a/src/import-sql/layers/place_label.sql
+++ b/src/import-sql/layers/place_label.sql
@@ -1,107 +1,51 @@
-CREATE OR REPLACE VIEW place_label_z4toz5 AS
-    SELECT * FROM (
-        SELECT osm_id, geometry, timestamp, name, name_int, name_fr, name_en, name_de,
-        name_es, name_ru, name_zh, type, population, capital, admin_level, scalerank
-        FROM osm_place_point
-        UNION ALL
-        SELECT osm_id, geometry, timestamp, name, name_int, name_fr, name_en, name_de,
-        name_es, name_ru, name_zh, type, population, capital, admin_level, scalerank
-        FROM osm_place_polygon
-    ) AS place_geoms
+CREATE OR REPLACE VIEW place_label_z4toz5 AS (
+    SELECT * FROM osm_place_geometry
     WHERE name IS NOT NULL
-        AND scalerank IS NOT NULL
-        AND scalerank < 3;
+      AND scalerank IS NOT NULL
+      AND scalerank < 3
+);
 
-CREATE OR REPLACE VIEW place_label_z6 AS
-    SELECT * FROM (
-        SELECT osm_id, geometry, timestamp, name, name_int, name_fr, name_en, name_de,
-        name_es, name_ru, name_zh, type, population, capital, admin_level, scalerank
-        FROM osm_place_point
-        UNION ALL
-        SELECT osm_id, geometry, timestamp, name, name_int, name_fr, name_en, name_de,
-        name_es, name_ru, name_zh, type, population, capital, admin_level, scalerank
-        FROM osm_place_polygon
-    ) AS place_geoms
+CREATE OR REPLACE VIEW place_label_z6 AS (
+    SELECT * FROM osm_place_geometry
     WHERE name IS NOT NULL
-        AND scalerank IS NOT NULL
-        AND scalerank < 8;
+      AND scalerank IS NOT NULL
+      AND scalerank < 8
+);
 
-CREATE OR REPLACE VIEW place_label_z7 AS
-    SELECT * FROM (
-        SELECT osm_id, geometry, timestamp, name, name_int, name_fr, name_en, name_de,
-        name_es, name_ru, name_zh, type, population, capital, admin_level, scalerank
-        FROM osm_place_point
-        UNION ALL
-        SELECT osm_id, geometry, timestamp, name, name_int, name_fr, name_en, name_de,
-        name_es, name_ru, name_zh, type, population, capital, admin_level, scalerank
-        FROM osm_place_polygon
-    ) AS place_geoms
+CREATE OR REPLACE VIEW place_label_z7 AS (
+    SELECT * FROM osm_place_geometry
     WHERE name IS NOT NULL
-        AND scalerank IS NOT NULL;
+      AND scalerank IS NOT NULL
+);
 
-CREATE OR REPLACE VIEW place_label_z8 AS
-    SELECT * FROM (
-        SELECT osm_id, geometry, timestamp, name, name_int, name_fr, name_en, name_de,
-        name_es, name_ru, name_zh, type, population, capital, admin_level, scalerank
-        FROM osm_place_point
-        UNION ALL
-        SELECT osm_id, geometry, timestamp, name, name_int, name_fr, name_en, name_de,
-        name_es, name_ru, name_zh, type, population, capital, admin_level, scalerank
-        FROM osm_place_polygon
-    ) AS place_geoms
+CREATE OR REPLACE VIEW place_label_z8 AS (
+    SELECT * FROM osm_place_geometry
     WHERE name IS NOT NULL
-        AND type IN ('city', 'town');
+      AND type IN ('city', 'town')
+);
 
-CREATE OR REPLACE VIEW place_label_z9toz10 AS
-    SELECT * FROM (
-        SELECT osm_id, geometry, timestamp, name, name_int, name_fr, name_en, name_de,
-        name_es, name_ru, name_zh, type, population, capital, admin_level, scalerank
-        FROM osm_place_point
-        UNION ALL
-        SELECT osm_id, geometry, timestamp, name, name_int, name_fr, name_en, name_de,
-        name_es, name_ru, name_zh, type, population, capital, admin_level, scalerank
-        FROM osm_place_polygon
-    ) AS place_geoms
+CREATE OR REPLACE VIEW place_label_z9toz10 AS (
+    SELECT * FROM osm_place_geometry
     WHERE name IS NOT NULL
-        AND type IN ('city', 'town', 'district');
+      AND type IN ('city', 'town', 'district')
+);
 
-CREATE OR REPLACE VIEW place_label_z11toz12 AS
-    SELECT * FROM (
-        SELECT osm_id, geometry, timestamp, name, name_int, name_fr, name_en, name_de,
-        name_es, name_ru, name_zh, type, population, capital, admin_level, scalerank
-        FROM osm_place_point
-        UNION ALL
-        SELECT osm_id, geometry, timestamp, name, name_int, name_fr, name_en, name_de,
-        name_es, name_ru, name_zh, type, population, capital, admin_level, scalerank
-        FROM osm_place_polygon
-    ) AS place_geoms
+CREATE OR REPLACE VIEW place_label_z11toz12 AS (
+    SELECT * FROM osm_place_geometry
     WHERE name IS NOT NULL
-        AND type IN ('city', 'town', 'district', 'village');
+      AND type IN ('city', 'town', 'district', 'village')
+);
 
-CREATE OR REPLACE VIEW place_label_z13 AS
-    SELECT * FROM (
-        SELECT osm_id, geometry, timestamp, name, name_int, name_fr, name_en, name_de,
-        name_es, name_ru, name_zh, type, population, capital, admin_level, scalerank
-        FROM osm_place_point
-        UNION ALL
-        SELECT osm_id, geometry, timestamp, name, name_int, name_fr, name_en, name_de,
-        name_es, name_ru, name_zh, type, population, capital, admin_level, scalerank
-        FROM osm_place_polygon
-    ) AS place_geoms
+CREATE OR REPLACE VIEW place_label_z13 AS (
+    SELECT * FROM osm_place_geometry
     WHERE name IS NOT NULL
-        AND type IN ('city', 'town', 'district', 'village', 'hamlet', 'suburb','neighbourhood');
+      AND type IN ('city', 'town', 'district', 'village', 'hamlet', 'suburb','neighbourhood')
+);
 
 CREATE OR REPLACE VIEW place_label_z14 AS
-    SELECT * FROM (
-        SELECT osm_id, geometry, timestamp, name, name_int, name_fr, name_en, name_de,
-        name_es, name_ru, name_zh, type, population, capital, admin_level, scalerank
-        FROM osm_place_point
-        UNION ALL
-        SELECT osm_id, geometry, timestamp, name, name_int, name_fr, name_en, name_de,
-        name_es, name_ru, name_zh, type, population, capital, admin_level, scalerank
-        FROM osm_place_polygon
-    ) AS place_geoms
-    WHERE name IS NOT NULL;
+    SELECT * FROM osm_place_geometry
+    WHERE name IS NOT NULL
+);
 
 CREATE OR REPLACE VIEW place_label_layer AS (
     SELECT osm_id, timestamp, geometry FROM place_label_z4toz5

--- a/src/import-sql/layers/place_label.sql
+++ b/src/import-sql/layers/place_label.sql
@@ -39,25 +39,25 @@ CREATE OR REPLACE VIEW place_label_z8 AS (
 CREATE OR REPLACE VIEW place_label_z9 AS (
     SELECT * FROM osm_place_geometry
     WHERE name <> ''
-      AND type IN ('island', 'islet', 'aboriginal_lands', 'city', 'town', 'village')
+      AND type IN ('island', 'islet', 'aboriginal_lands', 'city', 'town')
 );
 
 CREATE OR REPLACE VIEW place_label_z10 AS (
     SELECT * FROM osm_place_geometry
     WHERE name <> ''
-      AND type IN ('island', 'islet', 'aboriginal_lands', 'city', 'town', 'village', 'suburb')
+      AND type IN ('island', 'islet', 'aboriginal_lands', 'city', 'town', 'village')
 );
 
 CREATE OR REPLACE VIEW place_label_z11toz12 AS (
     SELECT * FROM osm_place_geometry
     WHERE name <> ''
-      AND type IN ('island', 'islet', 'aboriginal_lands', 'city', 'town', 'village', 'suburb', 'hamlet')
+      AND type IN ('island', 'islet', 'aboriginal_lands', 'city', 'town', 'village', 'suburb')
 );
 
 CREATE OR REPLACE VIEW place_label_z13 AS (
     SELECT * FROM osm_place_geometry
     WHERE name <> ''
-      AND type IN ('island', 'islet', 'aboriginal_lands', 'city', 'town', 'village', 'suburb', 'hamlet', 'neighbourhood', 'residential')
+      AND type IN ('island', 'islet', 'aboriginal_lands', 'city', 'town', 'village', 'suburb', 'hamlet')
 );
 
 CREATE OR REPLACE VIEW place_label_z14 AS (

--- a/src/import-sql/layers/place_label.sql
+++ b/src/import-sql/layers/place_label.sql
@@ -1,49 +1,49 @@
 CREATE OR REPLACE VIEW place_label_z4toz5 AS (
-    SELECT * FROM osm_place_point
+    SELECT * FROM osm_place_geometry
     WHERE name IS NOT NULL
       AND scalerank IS NOT NULL
       AND scalerank < 3
 );
 
 CREATE OR REPLACE VIEW place_label_z6 AS (
-    SELECT * FROM osm_place_point
+    SELECT * FROM osm_place_geometry
     WHERE name IS NOT NULL
       AND scalerank IS NOT NULL
       AND scalerank < 8
 );
 
 CREATE OR REPLACE VIEW place_label_z7 AS (
-    SELECT * FROM osm_place_point
+    SELECT * FROM osm_place_geometry
     WHERE name IS NOT NULL
       AND scalerank IS NOT NULL
 );
 
 CREATE OR REPLACE VIEW place_label_z8 AS (
-    SELECT * FROM osm_place_point
+    SELECT * FROM osm_place_geometry
     WHERE name IS NOT NULL
       AND type IN ('city', 'town')
 );
 
 CREATE OR REPLACE VIEW place_label_z9toz10 AS (
-    SELECT * FROM osm_place_point
+    SELECT * FROM osm_place_geometry
     WHERE name IS NOT NULL
       AND type IN ('city', 'town', 'district')
 );
 
 CREATE OR REPLACE VIEW place_label_z11toz12 AS (
-    SELECT * FROM osm_place_point
+    SELECT * FROM osm_place_geometry
     WHERE name IS NOT NULL
       AND type IN ('city', 'town', 'district', 'village', 'suburb')
 );
 
 CREATE OR REPLACE VIEW place_label_z13 AS (
-    SELECT * FROM osm_place_point
+    SELECT * FROM osm_place_geometry
     WHERE name IS NOT NULL
       AND type IN ('city', 'town', 'district', 'village', 'hamlet', 'suburb','neighbourhood')
 );
 
 CREATE OR REPLACE VIEW place_label_z14 AS (
-    SELECT * FROM osm_place_point
+    SELECT * FROM osm_place_geometry
     WHERE name IS NOT NULL
 );
 

--- a/src/import-sql/layers/place_label.sql
+++ b/src/import-sql/layers/place_label.sql
@@ -33,7 +33,7 @@ CREATE OR REPLACE VIEW place_label_z9toz10 AS (
 CREATE OR REPLACE VIEW place_label_z11toz12 AS (
     SELECT * FROM osm_place_point
     WHERE name IS NOT NULL
-      AND type IN ('city', 'town', 'district', 'village')
+      AND type IN ('city', 'town', 'district', 'village', 'suburb')
 );
 
 CREATE OR REPLACE VIEW place_label_z13 AS (

--- a/src/import-sql/layers/place_label.sql
+++ b/src/import-sql/layers/place_label.sql
@@ -42,7 +42,7 @@ CREATE OR REPLACE VIEW place_label_z13 AS (
       AND type IN ('city', 'town', 'district', 'village', 'hamlet', 'suburb','neighbourhood')
 );
 
-CREATE OR REPLACE VIEW place_label_z14 AS
+CREATE OR REPLACE VIEW place_label_z14 AS (
     SELECT * FROM osm_place_geometry
     WHERE name IS NOT NULL
 );

--- a/src/import-sql/layers/place_label.sql
+++ b/src/import-sql/layers/place_label.sql
@@ -1,49 +1,49 @@
 CREATE OR REPLACE VIEW place_label_z4toz5 AS (
-    SELECT * FROM osm_place_geometry
+    SELECT * FROM osm_place_point
     WHERE name IS NOT NULL
       AND scalerank IS NOT NULL
       AND scalerank < 3
 );
 
 CREATE OR REPLACE VIEW place_label_z6 AS (
-    SELECT * FROM osm_place_geometry
+    SELECT * FROM osm_place_point
     WHERE name IS NOT NULL
       AND scalerank IS NOT NULL
       AND scalerank < 8
 );
 
 CREATE OR REPLACE VIEW place_label_z7 AS (
-    SELECT * FROM osm_place_geometry
+    SELECT * FROM osm_place_point
     WHERE name IS NOT NULL
       AND scalerank IS NOT NULL
 );
 
 CREATE OR REPLACE VIEW place_label_z8 AS (
-    SELECT * FROM osm_place_geometry
+    SELECT * FROM osm_place_point
     WHERE name IS NOT NULL
       AND type IN ('city', 'town')
 );
 
 CREATE OR REPLACE VIEW place_label_z9toz10 AS (
-    SELECT * FROM osm_place_geometry
+    SELECT * FROM osm_place_point
     WHERE name IS NOT NULL
       AND type IN ('city', 'town', 'district')
 );
 
 CREATE OR REPLACE VIEW place_label_z11toz12 AS (
-    SELECT * FROM osm_place_geometry
+    SELECT * FROM osm_place_point
     WHERE name IS NOT NULL
       AND type IN ('city', 'town', 'district', 'village')
 );
 
 CREATE OR REPLACE VIEW place_label_z13 AS (
-    SELECT * FROM osm_place_geometry
+    SELECT * FROM osm_place_point
     WHERE name IS NOT NULL
       AND type IN ('city', 'town', 'district', 'village', 'hamlet', 'suburb','neighbourhood')
 );
 
 CREATE OR REPLACE VIEW place_label_z14 AS (
-    SELECT * FROM osm_place_geometry
+    SELECT * FROM osm_place_point
     WHERE name IS NOT NULL
 );
 

--- a/src/import-sql/layers/place_label.sql
+++ b/src/import-sql/layers/place_label.sql
@@ -1,62 +1,84 @@
-CREATE OR REPLACE VIEW place_label_z4toz5 AS (
+CREATE OR REPLACE VIEW place_label_z3 AS (
     SELECT * FROM osm_place_geometry
-    WHERE name IS NOT NULL
+    WHERE name <> ''
       AND scalerank IS NOT NULL
-      AND scalerank < 3
+      AND scalerank BETWEEN 1 AND 2
+      AND type = 'city'
 );
 
-CREATE OR REPLACE VIEW place_label_z6 AS (
+CREATE OR REPLACE VIEW place_label_z4 AS (
     SELECT * FROM osm_place_geometry
-    WHERE name IS NOT NULL
+    WHERE name <> ''
       AND scalerank IS NOT NULL
-      AND scalerank < 8
+      AND scalerank BETWEEN 1 AND 4
+      AND type = 'city'
 );
 
-CREATE OR REPLACE VIEW place_label_z7 AS (
+CREATE OR REPLACE VIEW place_label_z5 AS (
     SELECT * FROM osm_place_geometry
-    WHERE name IS NOT NULL
+    WHERE name <> ''
       AND scalerank IS NOT NULL
+      AND scalerank BETWEEN 1 AND 7
+      AND type = 'city'
+);
+
+CREATE OR REPLACE VIEW place_label_z6toz7 AS (
+    SELECT * FROM osm_place_geometry
+    WHERE name <> ''
+      AND scalerank IS NOT NULL
+      AND scalerank BETWEEN 1 AND 10
+      AND type IN ('city', 'town')
 );
 
 CREATE OR REPLACE VIEW place_label_z8 AS (
     SELECT * FROM osm_place_geometry
-    WHERE name IS NOT NULL
+    WHERE name <> ''
       AND type IN ('city', 'town')
 );
 
-CREATE OR REPLACE VIEW place_label_z9toz10 AS (
+CREATE OR REPLACE VIEW place_label_z9 AS (
     SELECT * FROM osm_place_geometry
-    WHERE name IS NOT NULL
-      AND type IN ('city', 'town', 'district')
+    WHERE name <> ''
+      AND type IN ('island', 'islet', 'aboriginal_lands', 'city', 'town', 'village')
+);
+
+CREATE OR REPLACE VIEW place_label_z10 AS (
+    SELECT * FROM osm_place_geometry
+    WHERE name <> ''
+      AND type IN ('island', 'islet', 'aboriginal_lands', 'city', 'town', 'village', 'suburb')
 );
 
 CREATE OR REPLACE VIEW place_label_z11toz12 AS (
     SELECT * FROM osm_place_geometry
-    WHERE name IS NOT NULL
-      AND type IN ('city', 'town', 'district', 'village', 'suburb')
+    WHERE name <> ''
+      AND type IN ('island', 'islet', 'aboriginal_lands', 'city', 'town', 'village', 'suburb', 'hamlet')
 );
 
 CREATE OR REPLACE VIEW place_label_z13 AS (
     SELECT * FROM osm_place_geometry
-    WHERE name IS NOT NULL
-      AND type IN ('city', 'town', 'district', 'village', 'hamlet', 'suburb','neighbourhood')
+    WHERE name <> ''
+      AND type IN ('island', 'islet', 'aboriginal_lands', 'city', 'town', 'village', 'suburb', 'hamlet', 'neighbourhood', 'residential')
 );
 
 CREATE OR REPLACE VIEW place_label_z14 AS (
     SELECT * FROM osm_place_geometry
-    WHERE name IS NOT NULL
+    WHERE name <> ''
 );
 
 CREATE OR REPLACE VIEW place_label_layer AS (
-    SELECT osm_id, timestamp, geometry FROM place_label_z4toz5
+    SELECT osm_id, timestamp, geometry FROM place_label_z3
     UNION
-    SELECT osm_id, timestamp, geometry FROM place_label_z6
+    SELECT osm_id, timestamp, geometry FROM place_label_z4
     UNION
-    SELECT osm_id, timestamp, geometry FROM place_label_z7
+    SELECT osm_id, timestamp, geometry FROM place_label_z5
+    UNION
+    SELECT osm_id, timestamp, geometry FROM place_label_z6toz7
     UNION
     SELECT osm_id, timestamp, geometry FROM place_label_z8
     UNION
-    SELECT osm_id, timestamp, geometry FROM place_label_z9toz10
+    SELECT osm_id, timestamp, geometry FROM place_label_z9
+    UNION
+    SELECT osm_id, timestamp, geometry FROM place_label_z10
     UNION
     SELECT osm_id, timestamp, geometry FROM place_label_z11toz12
     UNION
@@ -85,26 +107,34 @@ BEGIN
 
 		SELECT c.x, c.y, c.z FROM place_label_z11toz12 AS l
 		INNER JOIN changed_tiles AS c ON c.osm_id = l.osm_id AND c.z BETWEEN 11 AND 12
+        UNION
+
+        SELECT c.x, c.y, c.z FROM place_label_z10 AS l
+        INNER JOIN changed_tiles AS c ON c.osm_id = l.osm_id AND c.z = 10
 		UNION
 
-		SELECT c.x, c.y, c.z FROM place_label_z9toz10 AS l
-		INNER JOIN changed_tiles AS c ON c.osm_id = l.osm_id AND c.z BETWEEN 9 AND 10
+		SELECT c.x, c.y, c.z FROM place_label_z9 AS l
+		INNER JOIN changed_tiles AS c ON c.osm_id = l.osm_id AND c.z = 9
 		UNION
 
 		SELECT c.x, c.y, c.z FROM place_label_z8 AS l
 		INNER JOIN changed_tiles AS c ON c.osm_id = l.osm_id AND c.z = 8
 		UNION
 
-		SELECT c.x, c.y, c.z FROM place_label_z7 AS l
-		INNER JOIN changed_tiles AS c ON c.osm_id = l.osm_id AND c.z = 7
+		SELECT c.x, c.y, c.z FROM place_label_z6toz7 AS l
+		INNER JOIN changed_tiles AS c ON c.osm_id = l.osm_id AND c.z BETWEEN 6 AND 7
+        UNION
+
+        SELECT c.x, c.y, c.z FROM place_label_z5 AS l
+        INNER JOIN changed_tiles AS c ON c.osm_id = l.osm_id AND c.z = 5
+        UNION
+
+        SELECT c.x, c.y, c.z FROM place_label_z4 AS l
+        INNER JOIN changed_tiles AS c ON c.osm_id = l.osm_id AND c.z = 4
 		UNION
 
-		SELECT c.x, c.y, c.z FROM place_label_z6 AS l
-		INNER JOIN changed_tiles AS c ON c.osm_id = l.osm_id AND c.z = 6
-		UNION
-
-		SELECT c.x, c.y, c.z FROM place_label_z4toz5 AS l
-		INNER JOIN changed_tiles AS c ON c.osm_id = l.osm_id AND c.z BETWEEN 4 AND 5
+		SELECT c.x, c.y, c.z FROM place_label_z3 AS l
+		INNER JOIN changed_tiles AS c ON c.osm_id = l.osm_id AND c.z = 3
 	);
 END;
 $$ LANGUAGE plpgsql;

--- a/src/import-sql/triggers.sql
+++ b/src/import-sql/triggers.sql
@@ -69,8 +69,7 @@ CREATE OR REPLACE FUNCTION create_tracking_triggers() returns VOID
 AS $$
 BEGIN
     -- Place
-    PERFORM recreate_osm_delete_tracking('osm_place_point');
-    PERFORM recreate_osm_delete_tracking('osm_place_polygon');
+    PERFORM recreate_osm_delete_tracking('osm_place_geometry');
     -- POI
     PERFORM recreate_osm_delete_tracking('osm_poi_point');
     PERFORM recreate_osm_delete_tracking('osm_poi_polygon');
@@ -124,8 +123,7 @@ BEGIN
 	UPDATE osm_landuse_polygon SET timestamp=ts WHERE timestamp IS NULL;
 	UPDATE osm_landuse_polygon_gen0 SET timestamp=ts WHERE timestamp IS NULL;
 	UPDATE osm_landuse_polygon_gen1 SET timestamp=ts WHERE timestamp IS NULL;
-	UPDATE osm_place_point SET timestamp=ts WHERE timestamp IS NULL;
-    UPDATE osm_place_polygon SET timestamp=ts WHERE timestamp IS NULL;
+	UPDATE osm_place_geometry SET timestamp=ts WHERE timestamp IS NULL;
 	UPDATE osm_poi_point SET timestamp=ts WHERE timestamp IS NULL;
 	UPDATE osm_poi_polygon SET timestamp=ts WHERE timestamp IS NULL;
 	UPDATE osm_road_geometry SET timestamp=ts WHERE timestamp IS NULL;
@@ -160,8 +158,7 @@ BEGIN
     DROP TABLE osm_landuse_polygon CASCADE;
     DROP TABLE osm_landuse_polygon_gen0 CASCADE;
     DROP TABLE osm_landuse_polygon_gen1 CASCADE;
-    DROP TABLE osm_place_point CASCADE;
-    DROP TABLE osm_place_polygon CASCADE;
+    DROP TABLE osm_place_geometry CASCADE;
     DROP TABLE osm_poi_point CASCADE;
     DROP TABLE osm_poi_polygon CASCADE;
     DROP TABLE osm_road_geometry CASCADE;
@@ -180,8 +177,7 @@ $$ language plpgsql;
 CREATE OR REPLACE FUNCTION disable_delete_tracking() returns VOID
 AS $$
 BEGIN
-    ALTER TABLE osm_place_point DISABLE TRIGGER USER;
-    ALTER TABLE osm_place_polygon DISABLE TRIGGER USER;
+    ALTER TABLE osm_place_geometry DISABLE TRIGGER USER;
     ALTER TABLE osm_poi_point DISABLE TRIGGER USER;
     ALTER TABLE osm_poi_polygon DISABLE TRIGGER USER;
     ALTER TABLE osm_road_geometry DISABLE TRIGGER USER;
@@ -206,8 +202,7 @@ $$ language plpgsql;
 CREATE OR REPLACE FUNCTION enable_delete_tracking() returns VOID
 AS $$
 BEGIN
-    ALTER TABLE osm_place_point ENABLE TRIGGER USER;
-    ALTER TABLE osm_place_polygon ENABLE TRIGGER USER;
+    ALTER TABLE osm_place_geometry ENABLE TRIGGER USER;
     ALTER TABLE osm_poi_point ENABLE TRIGGER USER;
     ALTER TABLE osm_poi_polygon ENABLE TRIGGER USER;
     ALTER TABLE osm_road_geometry ENABLE TRIGGER USER;

--- a/src/import-sql/triggers.sql
+++ b/src/import-sql/triggers.sql
@@ -69,7 +69,7 @@ CREATE OR REPLACE FUNCTION create_tracking_triggers() returns VOID
 AS $$
 BEGIN
     -- Place
-    PERFORM recreate_osm_delete_tracking('osm_place_point');
+    PERFORM recreate_osm_delete_tracking('osm_place_geometry');
     -- POI
     PERFORM recreate_osm_delete_tracking('osm_poi_point');
     PERFORM recreate_osm_delete_tracking('osm_poi_polygon');
@@ -123,7 +123,7 @@ BEGIN
 	UPDATE osm_landuse_polygon SET timestamp=ts WHERE timestamp IS NULL;
 	UPDATE osm_landuse_polygon_gen0 SET timestamp=ts WHERE timestamp IS NULL;
 	UPDATE osm_landuse_polygon_gen1 SET timestamp=ts WHERE timestamp IS NULL;
-	UPDATE osm_place_point SET timestamp=ts WHERE timestamp IS NULL;
+	UPDATE osm_place_geometry SET timestamp=ts WHERE timestamp IS NULL;
 	UPDATE osm_poi_point SET timestamp=ts WHERE timestamp IS NULL;
 	UPDATE osm_poi_polygon SET timestamp=ts WHERE timestamp IS NULL;
 	UPDATE osm_road_geometry SET timestamp=ts WHERE timestamp IS NULL;
@@ -158,7 +158,7 @@ BEGIN
     DROP TABLE osm_landuse_polygon CASCADE;
     DROP TABLE osm_landuse_polygon_gen0 CASCADE;
     DROP TABLE osm_landuse_polygon_gen1 CASCADE;
-    DROP TABLE osm_place_point CASCADE;
+    DROP TABLE osm_place_geometry CASCADE;
     DROP TABLE osm_poi_point CASCADE;
     DROP TABLE osm_poi_polygon CASCADE;
     DROP TABLE osm_road_geometry CASCADE;
@@ -177,7 +177,7 @@ $$ language plpgsql;
 CREATE OR REPLACE FUNCTION disable_delete_tracking() returns VOID
 AS $$
 BEGIN
-    ALTER TABLE osm_place_point DISABLE TRIGGER USER;
+    ALTER TABLE osm_place_geometry DISABLE TRIGGER USER;
     ALTER TABLE osm_poi_point DISABLE TRIGGER USER;
     ALTER TABLE osm_poi_polygon DISABLE TRIGGER USER;
     ALTER TABLE osm_road_geometry DISABLE TRIGGER USER;
@@ -202,7 +202,7 @@ $$ language plpgsql;
 CREATE OR REPLACE FUNCTION enable_delete_tracking() returns VOID
 AS $$
 BEGIN
-    ALTER TABLE osm_place_point ENABLE TRIGGER USER;
+    ALTER TABLE osm_place_geometry ENABLE TRIGGER USER;
     ALTER TABLE osm_poi_point ENABLE TRIGGER USER;
     ALTER TABLE osm_poi_polygon ENABLE TRIGGER USER;
     ALTER TABLE osm_road_geometry ENABLE TRIGGER USER;

--- a/src/import-sql/triggers.sql
+++ b/src/import-sql/triggers.sql
@@ -69,7 +69,7 @@ CREATE OR REPLACE FUNCTION create_tracking_triggers() returns VOID
 AS $$
 BEGIN
     -- Place
-    PERFORM recreate_osm_delete_tracking('osm_place_geometry');
+    PERFORM recreate_osm_delete_tracking('osm_place_point');
     -- POI
     PERFORM recreate_osm_delete_tracking('osm_poi_point');
     PERFORM recreate_osm_delete_tracking('osm_poi_polygon');
@@ -123,7 +123,7 @@ BEGIN
 	UPDATE osm_landuse_polygon SET timestamp=ts WHERE timestamp IS NULL;
 	UPDATE osm_landuse_polygon_gen0 SET timestamp=ts WHERE timestamp IS NULL;
 	UPDATE osm_landuse_polygon_gen1 SET timestamp=ts WHERE timestamp IS NULL;
-	UPDATE osm_place_geometry SET timestamp=ts WHERE timestamp IS NULL;
+	UPDATE osm_place_point SET timestamp=ts WHERE timestamp IS NULL;
 	UPDATE osm_poi_point SET timestamp=ts WHERE timestamp IS NULL;
 	UPDATE osm_poi_polygon SET timestamp=ts WHERE timestamp IS NULL;
 	UPDATE osm_road_geometry SET timestamp=ts WHERE timestamp IS NULL;
@@ -158,7 +158,7 @@ BEGIN
     DROP TABLE osm_landuse_polygon CASCADE;
     DROP TABLE osm_landuse_polygon_gen0 CASCADE;
     DROP TABLE osm_landuse_polygon_gen1 CASCADE;
-    DROP TABLE osm_place_geometry CASCADE;
+    DROP TABLE osm_place_point CASCADE;
     DROP TABLE osm_poi_point CASCADE;
     DROP TABLE osm_poi_polygon CASCADE;
     DROP TABLE osm_road_geometry CASCADE;
@@ -177,7 +177,7 @@ $$ language plpgsql;
 CREATE OR REPLACE FUNCTION disable_delete_tracking() returns VOID
 AS $$
 BEGIN
-    ALTER TABLE osm_place_geometry DISABLE TRIGGER USER;
+    ALTER TABLE osm_place_point DISABLE TRIGGER USER;
     ALTER TABLE osm_poi_point DISABLE TRIGGER USER;
     ALTER TABLE osm_poi_polygon DISABLE TRIGGER USER;
     ALTER TABLE osm_road_geometry DISABLE TRIGGER USER;
@@ -202,7 +202,7 @@ $$ language plpgsql;
 CREATE OR REPLACE FUNCTION enable_delete_tracking() returns VOID
 AS $$
 BEGIN
-    ALTER TABLE osm_place_geometry ENABLE TRIGGER USER;
+    ALTER TABLE osm_place_point ENABLE TRIGGER USER;
     ALTER TABLE osm_poi_point ENABLE TRIGGER USER;
     ALTER TABLE osm_poi_polygon ENABLE TRIGGER USER;
     ALTER TABLE osm_road_geometry ENABLE TRIGGER USER;

--- a/src/update-scaleranks/update.sql
+++ b/src/update-scaleranks/update.sql
@@ -1,9 +1,9 @@
-UPDATE osm_place_point
+UPDATE osm_place_geometry
 SET scalerank = improved_places.scalerank
 FROM
 (
     SELECT osm.osm_id, ne.scalerank
-    FROM ne_10m_populated_places AS ne, osm_place_point AS osm
+    FROM ne_10m_populated_places AS ne, osm_place_geometry AS osm
     WHERE
     (
         ne.name ILIKE osm.name OR
@@ -20,28 +20,4 @@ FROM
     AND (osm.type = 'city' OR osm.type = 'town' OR osm.type = 'village')
     AND st_dwithin(ne.geom, osm.geometry, 50000)
     ) AS improved_places
-WHERE osm_place_point.osm_id = improved_places.osm_id;
-
-UPDATE osm_place_polygon
-SET scalerank = improved_places.scalerank
-FROM
-(
-    SELECT osm.osm_id, ne.scalerank
-    FROM ne_10m_populated_places AS ne, osm_place_polygon AS osm
-    WHERE
-    (
-        ne.name ILIKE osm.name OR
-        ne.name ILIKE osm.name_en OR
-        ne.namealt ILIKE osm.name OR
-        ne.namealt ILIKE osm.name_en OR
-        ne.meganame ILIKE osm.name OR
-        ne.meganame ILIKE osm.name_en OR
-        ne.gn_ascii ILIKE osm.name OR
-        ne.gn_ascii ILIKE osm.name_en OR
-        ne.nameascii ILIKE osm.name OR
-        ne.nameascii ILIKE osm.name_en
-    )
-    AND (osm.type = 'city' OR osm.type = 'town' OR osm.type = 'village')
-    AND st_dwithin(ne.geom, osm.geometry, 50000)
-    ) AS improved_places
-WHERE osm_place_polygon.osm_id = improved_places.osm_id;
+WHERE osm_place_geometry.osm_id = improved_places.osm_id;

--- a/src/update-scaleranks/update.sql
+++ b/src/update-scaleranks/update.sql
@@ -1,9 +1,9 @@
-UPDATE osm_place_point
+UPDATE osm_place_geometry
 SET scalerank = improved_places.scalerank
 FROM
 (
     SELECT osm.osm_id, ne.scalerank
-    FROM ne_10m_populated_places AS ne, osm_place_point AS osm
+    FROM ne_10m_populated_places AS ne, osm_place_geometry AS osm
     WHERE
     (
         ne.name ILIKE osm.name OR
@@ -20,4 +20,4 @@ FROM
     AND (osm.type = 'city' OR osm.type = 'town' OR osm.type = 'village')
     AND st_dwithin(ne.geom, osm.geometry, 50000)
     ) AS improved_places
-WHERE osm_place_point.osm_id = improved_places.osm_id;
+WHERE osm_place_geometry.osm_id = improved_places.osm_id;

--- a/src/update-scaleranks/update.sql
+++ b/src/update-scaleranks/update.sql
@@ -1,9 +1,9 @@
-UPDATE osm_place_geometry
+UPDATE osm_place_point
 SET scalerank = improved_places.scalerank
 FROM
 (
     SELECT osm.osm_id, ne.scalerank
-    FROM ne_10m_populated_places AS ne, osm_place_geometry AS osm
+    FROM ne_10m_populated_places AS ne, osm_place_point AS osm
     WHERE
     (
         ne.name ILIKE osm.name OR
@@ -20,4 +20,4 @@ FROM
     AND (osm.type = 'city' OR osm.type = 'town' OR osm.type = 'village')
     AND st_dwithin(ne.geom, osm.geometry, 50000)
     ) AS improved_places
-WHERE osm_place_geometry.osm_id = improved_places.osm_id;
+WHERE osm_place_point.osm_id = improved_places.osm_id;


### PR DESCRIPTION
- Combined point and polygon table to one geometry table
- Removed unnecessary mapping keys (region, county, district, municipality, locality)
- Reworked the zoom level views
- Resolves #239
- One problem remains: From z3 to z7 the filter is based on the scalerank, this works just fine. But from z8 to z14 the filter is based on the type, the result is not very good because for example on z10 suddenly all villages appear. We need to know which are the important villages, suburbs and so on.

Example:
On the right side is osm2vectortiles. The suburbs suddenly appear all together, whereas Mapbox Streets has already the most important suburbs shown one zoom level earlier.
![hnxuffdnkx](https://cloud.githubusercontent.com/assets/1810384/14498267/0a359d40-019a-11e6-9e4a-8f75498f2ea3.gif)
