### PR TITLE
Generalize water polygons on lower zoom levels

### DIFF
--- a/osm2vectortiles.tm2source/data.yml
+++ b/osm2vectortiles.tm2source/data.yml
@@ -143,17 +143,25 @@ Layer:
       srid: ''
       table: |-
         (
+          SELECT 0 AS osm_id, geom AS geometry FROM ne_110m_ocean
+          WHERE geom && !bbox!
+            AND z(!scale_denominator!) = 0
+          UNION ALL
           SELECT 0 AS osm_id, geom AS geometry FROM ne_50m_ocean
           WHERE geom && !bbox!
-            AND z(!scale_denominator!) BETWEEN 0 AND 2
+            AND z(!scale_denominator!) = 1
           UNION ALL
           SELECT 0 AS osm_id, geom AS geometry FROM ne_10m_ocean
           WHERE geom && !bbox!
-            AND z(!scale_denominator!) BETWEEN 3 AND 4
+            AND z(!scale_denominator!) BETWEEN 2 AND 3
+          UNION ALL
+          SELECT 0 AS osm_id, way AS geometry FROM osm_ocean_polygons_gen0
+          WHERE way && !bbox!
+            AND z(!scale_denominator!) BETWEEN 4 AND 7
           UNION ALL
           SELECT 0 AS osm_id, way AS geometry FROM osm_ocean_polygons
           WHERE way && !bbox!
-            AND z(!scale_denominator!) BETWEEN 5 AND 14
+            AND z(!scale_denominator!) BETWEEN 8 AND 14
           UNION ALL
           SELECT 0 AS osm_id, geom AS geometry FROM ne_110m_lakes
           WHERE geom && !bbox!

--- a/osm2vectortiles.tm2source/data.yml
+++ b/osm2vectortiles.tm2source/data.yml
@@ -143,13 +143,17 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT 0 AS osm_id, ST_SimplifyPreserveTopology(way, 200) AS geometry FROM osm_ocean_polygons
-          WHERE way && !bbox!
-            AND z(!scale_denominator!) = 0
+          SELECT 0 AS osm_id, geom AS geometry FROM ne_50m_ocean
+          WHERE geom && !bbox!
+            AND z(!scale_denominator!) BETWEEN 0 AND 2
+          UNION ALL
+          SELECT 0 AS osm_id, geom AS geometry FROM ne_10m_ocean
+          WHERE geom && !bbox!
+            AND z(!scale_denominator!) BETWEEN 3 AND 4
           UNION ALL
           SELECT 0 AS osm_id, way AS geometry FROM osm_ocean_polygons
           WHERE way && !bbox!
-            AND z(!scale_denominator!) BETWEEN 1 AND 14
+            AND z(!scale_denominator!) BETWEEN 5 AND 14
           UNION ALL
           SELECT 0 AS osm_id, geom AS geometry FROM ne_110m_lakes
           WHERE geom && !bbox!

--- a/src/import-external/Dockerfile
+++ b/src/import-external/Dockerfile
@@ -12,6 +12,11 @@ RUN mkdir -p /data/import \
     && rm water-polygons-split-3857.zip
 
 RUN mkdir -p /data/import \
+    && wget --quiet http://data.openstreetmapdata.com/simplified-water-polygons-complete-3857.zip \
+    && unzip -oj simplified-water-polygons-complete-3857.zip -d /data/import \
+    && rm simplified-water-polygons-complete-3857.zip
+
+RUN mkdir -p /data/import \
     && wget http://naciscdn.org/naturalearth/packages/natural_earth_vector.sqlite.zip \
     && unzip -oj natural_earth_vector.sqlite.zip -d /data/import \
     && rm natural_earth_vector.sqlite.zip

--- a/src/import-external/import-water.sh
+++ b/src/import-external/import-water.sh
@@ -5,6 +5,7 @@ set -o nounset
 
 readonly IMPORT_DATA_DIR=${IMPORT_DATA_DIR:-/data/import}
 readonly WATER_POLYGONS_FILE="$IMPORT_DATA_DIR/water_polygons.shp"
+readonly SIMPLIFIED_WATER_POLYGONS_FILE="$IMPORT_DATA_DIR/simplified_water_polygons.shp"
 
 source sql.sh
 
@@ -16,8 +17,13 @@ function import_shp() {
 
 function import_water() {
     local table_name="osm_ocean_polygons"
+    local simplified_table_name="osm_ocean_polygons_gen0"
+
     drop_table "$table_name"
     import_shp "$WATER_POLYGONS_FILE" "$table_name"
+
+    drop_table "$simplified_table_name"
+    import_shp "$SIMPLIFIED_WATER_POLYGONS_FILE" "$simplified_table_name"
 }
 
 import_water


### PR DESCRIPTION
- Resolves #162 
- Improved the water layer query to use natural earth data and new similified water polygons data
  - z0: ne_110m_ocean
  - z1: ne_50m_ocean
  - z2toz3: ne_10m_ocean
  - z4toz7: osm_ocean_polygons_gen0 (source: http://data.openstreetmapdata.com/simplified-water-polygons-complete-3857.zip)
  - z8toz14: osm_ocean_polygons (source: http://data.openstreetmapdata.com/water-polygons-split-3857.zip)
- We overlook that there is actually a simplified version of the water polygons on openstreetmapdata.com