### PR TITLE
Cluster landuse polygons on zoom level 5 to 8

### DIFF
--- a/osm2vectortiles.tm2source/data.yml
+++ b/osm2vectortiles.tm2source/data.yml
@@ -46,20 +46,8 @@ Layer:
           SELECT osm_id_polygon(osm_id) as osm_id, geometry, landuse_class(type) as class, type
             FROM (
               SELECT osm_id, geometry, type
-              FROM landuse_z5
-              WHERE z(!scale_denominator!) = 5
-              UNION ALL
-              SELECT osm_id, geometry, type
-              FROM landuse_z6
-              WHERE z(!scale_denominator!) = 6
-              UNION ALL
-              SELECT osm_id, geometry, type
-              FROM landuse_z7
-              WHERE z(!scale_denominator!) = 7
-              UNION ALL
-              SELECT osm_id, geometry, type
-              FROM landuse_z8
-              WHERE z(!scale_denominator!) = 8
+              FROM landuse_z5toz8
+              WHERE z(!scale_denominator!) BETWEEN 5 AND 8
               UNION ALL
               SELECT osm_id, geometry, type
               FROM landuse_z9

--- a/src/import-osm/import.sh
+++ b/src/import-osm/import.sh
@@ -38,6 +38,9 @@ function import_pbf() {
     echo "Create osm_water_point table with precalculated centroids"
     create_osm_water_point_table
 
+    echo "Create osm_landuse_clustered table"
+    create_osm_landuse_clustered_table
+
     local timestamp=$(extract_timestamp "$pbf_file")
     store_timestamp_history "$timestamp"
 }
@@ -45,6 +48,10 @@ function import_pbf() {
 function extract_timestamp() {
     local file="$1"
     osmconvert "$file" --out-timestamp
+}
+
+function create_osm_landuse_clustered_table() {
+    exec_sql_file "landuse_clustered_table.sql"
 }
 
 function create_osm_water_point_table() {

--- a/src/import-osm/landuse_clustered_table.sql
+++ b/src/import-osm/landuse_clustered_table.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS osm_landuse_clustered CASCADE;
+CREATE TABLE osm_landuse_clustered AS
+SELECT ST_CollectionExtract(unnest(ST_ClusterWithin(geometry, 5000)),3) AS geometry                    
+FROM osm_landuse_polygon_gen0                                                                         
+WHERE type IN ('wood');
+
+CREATE INDEX ON osm_landuse_clustered USING gist (geometry);
+CREATE INDEX ON osm_landuse_clustered
+USING btree (st_geohash(st_transform(st_setsrid(box2d(geometry)::geometry, 3857), 4326)));

--- a/src/import-sql/layers/landuse.sql
+++ b/src/import-sql/layers/landuse.sql
@@ -32,15 +32,15 @@ CREATE OR REPLACE VIEW landuse_z13toz14 AS
     WHERE type NOT IN ('wetland', 'marsh', 'swamp', 'bog', 'mud', 'tidalflat', 'national_park', 'nature_reserve', 'protected_area');
 
 CREATE OR REPLACE VIEW landuse_layer AS (
-    SELECT osm_id, timestamp, geometry FROM landuse_z5toz8
+    SELECT osm_id FROM landuse_z5toz8
     UNION
-    SELECT osm_id, timestamp, geometry FROM landuse_z9
+    SELECT osm_id FROM landuse_z9
     UNION
-    SELECT osm_id, timestamp, geometry FROM landuse_z10
+    SELECT osm_id FROM landuse_z10
     UNION
-    SELECT osm_id, timestamp, geometry FROM landuse_z11
+    SELECT osm_id FROM landuse_z11
     UNION
-    SELECT osm_id, timestamp, geometry FROM landuse_z12
+    SELECT osm_id FROM landuse_z12
     UNION
-    SELECT osm_id, timestamp, geometry FROM landuse_z13toz14
+    SELECT osm_id FROM landuse_z13toz14
 );

--- a/src/import-sql/layers/landuse.sql
+++ b/src/import-sql/layers/landuse.sql
@@ -1,26 +1,6 @@
-CREATE OR REPLACE VIEW landuse_z5 AS
-    SELECT *
-    FROM osm_landuse_polygon_gen0
-    WHERE landuse_class(type) IN ('wood', 'grass')
-      AND st_area(geometry) > 300000000;
-
-CREATE OR REPLACE VIEW landuse_z6 AS
-    SELECT *
-    FROM osm_landuse_polygon_gen0
-    WHERE landuse_class(type) IN ('wood', 'grass')
-      AND st_area(geometry) > 100000000;
-
-CREATE OR REPLACE VIEW landuse_z7 AS
-    SELECT *
-    FROM osm_landuse_polygon_gen0
-    WHERE landuse_class(type) IN ('wood', 'grass')
-      AND st_area(geometry) > 25000000;
-
-CREATE OR REPLACE VIEW landuse_z8 AS
-    SELECT *
-    FROM osm_landuse_polygon_gen0
-    WHERE landuse_class(type) IN ('wood', 'grass')
-      AND st_area(geometry) > 5000000;
+CREATE OR REPLACE VIEW landuse_z5toz8 AS
+    SELECT 0 AS osm_id, geometry, 'wood' AS type
+    FROM osm_landuse_clustered;
 
 CREATE OR REPLACE VIEW landuse_z9 AS
     SELECT *
@@ -52,13 +32,7 @@ CREATE OR REPLACE VIEW landuse_z13toz14 AS
     WHERE type NOT IN ('wetland', 'marsh', 'swamp', 'bog', 'mud', 'tidalflat', 'national_park', 'nature_reserve', 'protected_area');
 
 CREATE OR REPLACE VIEW landuse_layer AS (
-    SELECT osm_id, timestamp, geometry FROM landuse_z5
-    UNION
-    SELECT osm_id, timestamp, geometry FROM landuse_z6
-    UNION
-    SELECT osm_id, timestamp, geometry FROM landuse_z7
-    UNION
-    SELECT osm_id, timestamp, geometry FROM landuse_z8
+    SELECT osm_id, timestamp, geometry FROM landuse_z5toz8
     UNION
     SELECT osm_id, timestamp, geometry FROM landuse_z9
     UNION


### PR DESCRIPTION
- Resolves #254 
- Creates a table osm_landuse_clustered after osm_import process
- Uses this new table for zoom level 5 to 8
- Detail explanation of how the clustering is done, can be found in issue #254 
- @lukasmartinelli Are both of this indexes needed?
```sql
CREATE INDEX ON osm_landuse_clustered USING gist (geometry);
CREATE INDEX ON osm_landuse_clustered
USING btree (st_geohash(st_transform(st_setsrid(box2d(geometry)::geometry, 3857), 4326)));
```
- We need to test this on a bigger data set, to verify if the distance value is good and the tiles are not getting to big.