### PR TITLE
Remove unneeded columns timestamp and geometry of layer views

### DIFF
--- a/src/import-sql/layers/aeroway.sql
+++ b/src/import-sql/layers/aeroway.sql
@@ -15,8 +15,8 @@ CREATE OR REPLACE VIEW aeroway_z10toz14 AS
     FROM osm_aero_polygon;
 
 CREATE OR REPLACE VIEW aeroway_layer AS (
-    SELECT osm_id, timestamp, geometry FROM aeroway_z9
+    SELECT osm_id FROM aeroway_z9
     UNION
-    SELECT osm_id, timestamp, geometry FROM aeroway_z10toz14
+    SELECT osm_id FROM aeroway_z10toz14
 );
 

--- a/src/import-sql/layers/airport_label.sql
+++ b/src/import-sql/layers/airport_label.sql
@@ -1,14 +1,14 @@
 CREATE OR REPLACE VIEW airport_label_z9toz14 AS
     SELECT osm_id, geometry, name, name_en, name_es, name_fr, name_de, name_ru, name_zh, 
-        iata, ref, icao, faa, aerodrome, type, kind, 0 AS area, timestamp
+        iata, ref, icao, faa, aerodrome, type, kind, 0 AS area
     FROM osm_airport_point
     UNION ALL
     SELECT osm_id, geometry, name, name_en, name_es, name_fr, name_de,
-        name_ru, name_zh, iata, ref, icao, faa, aerodrome, type, kind, area, timestamp
+        name_ru, name_zh, iata, ref, icao, faa, aerodrome, type, kind, area
     FROM osm_airport_polygon;
 
 CREATE OR REPLACE VIEW airport_label_layer AS (
-    SELECT osm_id, timestamp, geometry FROM airport_label_z9toz14
+    SELECT osm_id FROM airport_label_z9toz14
 );
 
 CREATE OR REPLACE FUNCTION airport_label_scalerank(maki VARCHAR, area REAL, aerodrome VARCHAR) RETURNS INTEGER

--- a/src/import-sql/layers/barrier_line.sql
+++ b/src/import-sql/layers/barrier_line.sql
@@ -6,5 +6,5 @@ CREATE OR REPLACE VIEW barrier_line_z14 AS
     FROM osm_barrier_polygon;
 
 CREATE OR REPLACE VIEW barrier_line_layer AS (
-    SELECT osm_id, timestamp, geometry FROM barrier_line_z14
+    SELECT osm_id FROM barrier_line_z14
 );

--- a/src/import-sql/layers/building.sql
+++ b/src/import-sql/layers/building.sql
@@ -7,9 +7,9 @@ CREATE OR REPLACE VIEW building_z14 AS
     FROM osm_building_polygon;
 
 CREATE OR REPLACE VIEW building_layer AS (
-    SELECT osm_id, timestamp, geometry FROM building_z13
+    SELECT osm_id FROM building_z13
     UNION
-    SELECT osm_id, timestamp, geometry FROM building_z14
+    SELECT osm_id FROM building_z14
 );
 
 CREATE OR REPLACE FUNCTION building_is_underground(level INTEGER) RETURNS VARCHAR

--- a/src/import-sql/layers/housenum_label.sql
+++ b/src/import-sql/layers/housenum_label.sql
@@ -1,10 +1,10 @@
 CREATE OR REPLACE VIEW housenum_label_z14 AS
-    SELECT osm_id, geometry, house_num, timestamp
+    SELECT osm_id, geometry, house_num
     FROM osm_housenumber_point
     UNION ALL
-    SELECT osm_id, geometry, house_num, timestamp
+    SELECT osm_id, geometry, house_num
     FROM osm_housenumber_polygon;
 
 CREATE OR REPLACE VIEW housenum_label_layer AS (
-    SELECT osm_id, timestamp, geometry FROM housenum_label_z14
+    SELECT osm_id FROM housenum_label_z14
 );

--- a/src/import-sql/layers/landuse_overlay.sql
+++ b/src/import-sql/layers/landuse_overlay.sql
@@ -46,19 +46,19 @@ CREATE OR REPLACE VIEW landuse_overlay_z13toz14 AS
     WHERE is_landuse_overlay(type);
 
 CREATE OR REPLACE VIEW landuse_overlay_layer AS (
-    SELECT osm_id, timestamp, geometry FROM landuse_overlay_z5
+    SELECT osm_id FROM landuse_overlay_z5
     UNION
-    SELECT osm_id, timestamp, geometry FROM landuse_overlay_z6
+    SELECT osm_id FROM landuse_overlay_z6
     UNION
-    SELECT osm_id, timestamp, geometry FROM landuse_overlay_z7
+    SELECT osm_id FROM landuse_overlay_z7
     UNION
-    SELECT osm_id, timestamp, geometry FROM landuse_overlay_z8
+    SELECT osm_id FROM landuse_overlay_z8
     UNION
-    SELECT osm_id, timestamp, geometry FROM landuse_overlay_z9
+    SELECT osm_id FROM landuse_overlay_z9
     UNION
-    SELECT osm_id, timestamp, geometry FROM landuse_overlay_z10
+    SELECT osm_id FROM landuse_overlay_z10
     UNION
-    SELECT osm_id, timestamp, geometry FROM landuse_overlay_z11toz12
+    SELECT osm_id FROM landuse_overlay_z11toz12
     UNION
-    SELECT osm_id, timestamp, geometry FROM landuse_overlay_z13toz14
+    SELECT osm_id FROM landuse_overlay_z13toz14
 );

--- a/src/import-sql/layers/mountain_peak_label.sql
+++ b/src/import-sql/layers/mountain_peak_label.sql
@@ -3,7 +3,7 @@ CREATE OR REPLACE VIEW mountain_peak_label_z12toz14 AS
     FROM osm_mountain_peak_point;
 
 CREATE OR REPLACE VIEW mountain_peak_label_layer AS (
-    SELECT osm_id, timestamp, geometry FROM mountain_peak_label_z12toz14
+    SELECT osm_id FROM mountain_peak_label_z12toz14
 );
 
 CREATE OR REPLACE FUNCTION meter_to_feet(meter INTEGER) RETURNS INTEGER

--- a/src/import-sql/layers/place_label.sql
+++ b/src/import-sql/layers/place_label.sql
@@ -66,23 +66,23 @@ CREATE OR REPLACE VIEW place_label_z14 AS (
 );
 
 CREATE OR REPLACE VIEW place_label_layer AS (
-    SELECT osm_id, timestamp, geometry FROM place_label_z4
+    SELECT osm_id FROM place_label_z4
     UNION
-    SELECT osm_id, timestamp, geometry FROM place_label_z5
+    SELECT osm_id FROM place_label_z5
     UNION
-    SELECT osm_id, timestamp, geometry FROM place_label_z6toz7
+    SELECT osm_id FROM place_label_z6toz7
     UNION
-    SELECT osm_id, timestamp, geometry FROM place_label_z8
+    SELECT osm_id FROM place_label_z8
     UNION
-    SELECT osm_id, timestamp, geometry FROM place_label_z9
+    SELECT osm_id FROM place_label_z9
     UNION
-    SELECT osm_id, timestamp, geometry FROM place_label_z10
+    SELECT osm_id FROM place_label_z10
     UNION
-    SELECT osm_id, timestamp, geometry FROM place_label_z11toz12
+    SELECT osm_id FROM place_label_z11toz12
     UNION
-    SELECT osm_id, timestamp, geometry FROM place_label_z13
+    SELECT osm_id FROM place_label_z13
     UNION
-    SELECT osm_id, timestamp, geometry FROM place_label_z14
+    SELECT osm_id FROM place_label_z14
 );
 
 CREATE OR REPLACE FUNCTION normalize_scalerank(scalerank INTEGER) RETURNS INTEGER

--- a/src/import-sql/layers/poi_label.sql
+++ b/src/import-sql/layers/poi_label.sql
@@ -1,18 +1,18 @@
 CREATE OR REPLACE VIEW poi_label_z14 AS (
     SELECT * FROM (
         SELECT geometry, osm_id, ref, name, name_en, name_es, name_fr,
-        name_de, name_ru, name_zh, type, 0 AS area, timestamp
+        name_de, name_ru, name_zh, type, 0 AS area
         FROM osm_poi_point
         UNION ALL
         SELECT geometry, osm_id, ref, name, name_en, name_es, name_fr,
-        name_de, name_ru, name_zh, type, area, timestamp
+        name_de, name_ru, name_zh, type, area
         FROM osm_poi_polygon
     ) AS poi_geoms
     WHERE name IS NOT NULL AND name <> ''
 );
 
 CREATE OR REPLACE VIEW poi_label_layer AS (
-    SELECT osm_id, timestamp, geometry FROM poi_label_z14
+    SELECT osm_id FROM poi_label_z14
 );
 
 CREATE OR REPLACE FUNCTION poi_label_localrank(type VARCHAR) RETURNS INTEGER

--- a/src/import-sql/layers/rail_station_label.sql
+++ b/src/import-sql/layers/rail_station_label.sql
@@ -10,7 +10,7 @@ CREATE OR REPLACE VIEW rail_station_label_z12toz13 AS (
 );
 
 CREATE OR REPLACE VIEW rail_station_label_layer AS (
-    SELECT osm_id, timestamp, geometry FROM rail_station_label_z12toz13
+    SELECT osm_id FROM rail_station_label_z12toz13
     UNION ALL
-    SELECT osm_id, timestamp, geometry FROM rail_station_label_z14
+    SELECT osm_id FROM rail_station_label_z14
 );

--- a/src/import-sql/layers/road.sql
+++ b/src/import-sql/layers/road.sql
@@ -25,60 +25,60 @@ END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
 CREATE OR REPLACE VIEW road_z5 AS
-    SELECT osm_id, geometry, type, construction, tracktype, service, access, oneway, 'none' AS structure, z_order, timestamp
+    SELECT osm_id, geometry, type, construction, tracktype, service, access, oneway, 'none' AS structure, z_order
     FROM osm_road_geometry
     WHERE road_class(type, service, access) IN ('motorway', 'trunk');
 
 CREATE OR REPLACE VIEW road_z6toz7 AS
-    SELECT osm_id, geometry, type, construction, tracktype, service, access, oneway, 'none' AS structure, z_order, timestamp
+    SELECT osm_id, geometry, type, construction, tracktype, service, access, oneway, 'none' AS structure, z_order
     FROM osm_road_geometry
     WHERE road_class(type, service, access) IN ('motorway', 'trunk', 'primary');
 
 CREATE OR REPLACE VIEW road_z8toz9 AS
-    SELECT osm_id, geometry, type, construction, tracktype, service, access, oneway, 'none' AS structure, z_order, timestamp
+    SELECT osm_id, geometry, type, construction, tracktype, service, access, oneway, 'none' AS structure, z_order
     FROM osm_road_geometry
     WHERE road_class(type, service, access) IN ('motorway', 'motorway_link', 'trunk', 'primary', 'secondary', 'major_rail');
 
 CREATE OR REPLACE VIEW road_z10 AS
-    SELECT osm_id, geometry, type, construction, tracktype, service, access, oneway, 'none' AS structure, z_order, timestamp
+    SELECT osm_id, geometry, type, construction, tracktype, service, access, oneway, 'none' AS structure, z_order
     FROM osm_road_geometry
     WHERE road_class(type, service, access) IN ('motorway', 'motorway_link', 'trunk', 'primary', 'secondary', 'tertiary', 'major_rail');
 
 CREATE OR REPLACE VIEW road_z11 AS
-    SELECT osm_id, geometry, type, construction, tracktype, service, access, oneway, 'none' AS structure, z_order, timestamp
+    SELECT osm_id, geometry, type, construction, tracktype, service, access, oneway, 'none' AS structure, z_order
     FROM osm_road_geometry
     WHERE road_class(type, service, access) IN ('motorway', 'motorway_link', 'trunk', 'primary', 'secondary', 'tertiary', 'major_rail', 'street', 'ferry');
 
 CREATE OR REPLACE VIEW road_z12 AS
-    SELECT osm_id, geometry, type, construction, tracktype, service, access, oneway, 'none' AS structure, z_order, timestamp
+    SELECT osm_id, geometry, type, construction, tracktype, service, access, oneway, 'none' AS structure, z_order
     FROM osm_road_geometry
     WHERE road_type_class(type) IN ('motorway', 'motorway_link', 'trunk', 'primary', 'secondary', 'tertiary', 'major_rail', 'street', 'ferry', 'service', 'link', 'construction', 'street_limited', 'aerialway');
 
 CREATE OR REPLACE VIEW road_z13 AS
-    SELECT osm_id, geometry, type, construction, tracktype, service, access, oneway, road_structure(is_tunnel, is_bridge, is_ford) AS structure, z_order, timestamp
+    SELECT osm_id, geometry, type, construction, tracktype, service, access, oneway, road_structure(is_tunnel, is_bridge, is_ford) AS structure, z_order
     FROM osm_road_geometry
     WHERE road_type_class(type) IN ('motorway', 'motorway_link', 'trunk', 'primary', 'secondary', 'tertiary', 'major_rail', 'street', 'ferry', 'service', 'link', 'construction', 'street_limited', 'aerialway', 'track');
 
 CREATE OR REPLACE VIEW road_z14 AS
-    SELECT osm_id, geometry, type, construction, tracktype, service, access, oneway, road_structure(is_tunnel, is_bridge, is_ford) AS structure, z_order, timestamp
+    SELECT osm_id, geometry, type, construction, tracktype, service, access, oneway, road_structure(is_tunnel, is_bridge, is_ford) AS structure, z_order
     FROM osm_road_geometry;
 
 CREATE OR REPLACE VIEW road_layer AS (
-    SELECT osm_id, timestamp, geometry FROM road_z5
+    SELECT osm_id FROM road_z5
     UNION
-    SELECT osm_id, timestamp, geometry FROM road_z6toz7
+    SELECT osm_id FROM road_z6toz7
     UNION
-    SELECT osm_id, timestamp, geometry FROM road_z8toz9
+    SELECT osm_id FROM road_z8toz9
     UNION
-    SELECT osm_id, timestamp, geometry FROM road_z10
+    SELECT osm_id FROM road_z10
     UNION
-    SELECT osm_id, timestamp, geometry FROM road_z11
+    SELECT osm_id FROM road_z11
     UNION
-    SELECT osm_id, timestamp, geometry FROM road_z12
+    SELECT osm_id FROM road_z12
     UNION
-    SELECT osm_id, timestamp, geometry FROM road_z13
+    SELECT osm_id FROM road_z13
     UNION
-    SELECT osm_id, timestamp, geometry FROM road_z14
+    SELECT osm_id FROM road_z14
 );
 
 CREATE OR REPLACE FUNCTION road_localrank(type VARCHAR) RETURNS INTEGER

--- a/src/import-sql/layers/road_label.sql
+++ b/src/import-sql/layers/road_label.sql
@@ -26,11 +26,11 @@ CREATE OR REPLACE VIEW road_label_z14 AS
       AND name <> '';
 
 CREATE OR REPLACE VIEW road_label_layer AS (
-    SELECT osm_id, timestamp, geometry FROM road_label_z8toz10
+    SELECT osm_id FROM road_label_z8toz10
     UNION
-    SELECT osm_id, timestamp, geometry FROM road_label_z11
+    SELECT osm_id FROM road_label_z11
     UNION
-    SELECT osm_id, timestamp, geometry FROM road_label_z12toz13
+    SELECT osm_id FROM road_label_z12toz13
     UNION
-    SELECT osm_id, timestamp, geometry FROM road_label_z14
+    SELECT osm_id FROM road_label_z14
 );

--- a/src/import-sql/layers/water_label.sql
+++ b/src/import-sql/layers/water_label.sql
@@ -1,35 +1,35 @@
 CREATE OR REPLACE VIEW water_label_z10 AS
-    SELECT osm_id, geometry, area, name, name_en, name_es, name_fr, name_de, name_ru, name_zh, timestamp
+    SELECT osm_id, geometry, area, name, name_en, name_es, name_fr, name_de, name_ru, name_zh
     FROM osm_water_point
     WHERE area >= 100000000;
 
 CREATE OR REPLACE VIEW water_label_z11 AS
-    SELECT osm_id, geometry, area, name, name_en, name_es, name_fr, name_de, name_ru, name_zh, timestamp
+    SELECT osm_id, geometry, area, name, name_en, name_es, name_fr, name_de, name_ru, name_zh
     FROM osm_water_point
     WHERE area >= 40000000;
 
 CREATE OR REPLACE VIEW water_label_z12 AS
-    SELECT osm_id, geometry, area, name, name_en, name_es, name_fr, name_de, name_ru, name_zh, timestamp
+    SELECT osm_id, geometry, area, name, name_en, name_es, name_fr, name_de, name_ru, name_zh
     FROM osm_water_point
     WHERE area >= 20000000;
 
 CREATE OR REPLACE VIEW water_label_z13 AS
-    SELECT osm_id, geometry, area, name, name_en, name_es, name_fr, name_de, name_ru, name_zh, timestamp
+    SELECT osm_id, geometry, area, name, name_en, name_es, name_fr, name_de, name_ru, name_zh
     FROM osm_water_point
     WHERE area >= 10000000;
 
 CREATE OR REPLACE VIEW water_label_z14 AS
-    SELECT osm_id, geometry, area, name, name_en, name_es, name_fr, name_de, name_ru, name_zh, timestamp
+    SELECT osm_id, geometry, area, name, name_en, name_es, name_fr, name_de, name_ru, name_zh
     FROM osm_water_point;
 
 CREATE OR REPLACE VIEW water_label_layer AS (
-    SELECT osm_id, timestamp, geometry FROM water_label_z10
+    SELECT osm_id FROM water_label_z10
     UNION
-    SELECT osm_id, timestamp, geometry FROM water_label_z11
+    SELECT osm_id FROM water_label_z11
     UNION
-    SELECT osm_id, timestamp, geometry FROM water_label_z12
+    SELECT osm_id FROM water_label_z12
     UNION
-    SELECT osm_id, timestamp, geometry FROM water_label_z13
+    SELECT osm_id FROM water_label_z13
     UNION
-    SELECT osm_id, timestamp, geometry FROM water_label_z14
+    SELECT osm_id FROM water_label_z14
 );

--- a/src/import-sql/layers/waterway.sql
+++ b/src/import-sql/layers/waterway.sql
@@ -14,9 +14,9 @@ CREATE OR REPLACE VIEW waterway_z14 AS
     WHERE type IN ('river', 'canal', 'stream', 'stream_intermittent', 'ditch', 'drain');
 
 CREATE OR REPLACE VIEW waterway_layer AS (
-    SELECT osm_id, timestamp, geometry FROM waterway_z8toz12
+    SELECT osm_id FROM waterway_z8toz12
     UNION
-    SELECT osm_id, timestamp, geometry FROM waterway_z13
+    SELECT osm_id FROM waterway_z13
     UNION
-    SELECT osm_id, timestamp, geometry FROM waterway_z14
+    SELECT osm_id FROM waterway_z14
 );

--- a/src/import-sql/layers/waterway_label.sql
+++ b/src/import-sql/layers/waterway_label.sql
@@ -14,9 +14,9 @@ CREATE OR REPLACE VIEW waterway_label_z14 AS
     WHERE type IN ('river', 'canal', 'stream', 'stream_intermittent', 'ditch', 'drain');
 
 CREATE OR REPLACE VIEW waterway_label_layer AS (
-    SELECT osm_id, timestamp, geometry FROM waterway_label_z8toz12
+    SELECT osm_id FROM waterway_label_z8toz12
     UNION
-    SELECT osm_id, timestamp, geometry FROM waterway_label_z13
+    SELECT osm_id FROM waterway_label_z13
     UNION
-    SELECT osm_id, timestamp, geometry FROM waterway_label_z14
+    SELECT osm_id FROM waterway_label_z14
 );


### PR DESCRIPTION
- As the changed tile process works now directly on the tables the fields timestamp and geometry are not needed in the layer views.