### PR TITLE
Update place_point table to create points

### DIFF
--- a/src/import-osm/import.sh
+++ b/src/import-osm/import.sh
@@ -38,6 +38,9 @@ function import_pbf() {
     echo "Create osm_water_point table with precalculated centroids"
     create_osm_water_point_table
 
+    echo "Update osm_place_polygon with point geometry"
+    update_place_point
+
     echo "Create osm_landuse_clustered table"
     create_osm_landuse_clustered_table
 
@@ -51,6 +54,10 @@ function import_pbf() {
 function extract_timestamp() {
     local file="$1"
     osmconvert "$file" --out-timestamp
+}
+
+function update_place_point() {
+    exec_sql_file "place_point_update.sql"
 }
 
 function update_scaleranks() {
@@ -163,6 +170,12 @@ function import_pbf_diffs() {
 
     echo "Disable change tracking"
     disable_delete_tracking
+
+    echo "Create osm_water_point table with precalculated centroids"
+    create_osm_water_point_table
+
+    echo "Update osm_place_polygon with point geometry"
+    update_place_point
 
     local timestamp=$(extract_timestamp "$diffs_file")
     echo "Set $timestamp for latest updates from $diffs_file"

--- a/src/import-osm/mapping.yml
+++ b/src/import-osm/mapping.yml
@@ -399,7 +399,7 @@ tables:
       - zoo
       - camp_site
     type: polygon
-  place_geometry:
+  place_point:
     type: geometry
     fields:
     - name: osm_id

--- a/src/import-osm/place_point_update.sql
+++ b/src/import-osm/place_point_update.sql
@@ -1,0 +1,3 @@
+UPDATE osm_place_point
+SET geometry = topoint(geometry)
+WHERE ST_GeometryType(geometry) <> 'ST_Point';

--- a/src/import-osm/update_scaleranks.sql
+++ b/src/import-osm/update_scaleranks.sql
@@ -1,9 +1,9 @@
-UPDATE osm_place_geometry
+UPDATE osm_place_point
 SET scalerank = improved_places.scalerank
 FROM
 (
     SELECT osm.osm_id, ne.scalerank
-    FROM ne_10m_populated_places AS ne, osm_place_geometry AS osm
+    FROM ne_10m_populated_places AS ne, osm_place_point AS osm
     WHERE
     (
         ne.name ILIKE osm.name OR
@@ -20,4 +20,4 @@ FROM
     AND (osm.type = 'city' OR osm.type = 'town' OR osm.type = 'village')
     AND st_dwithin(ne.geom, osm.geometry, 50000)
     ) AS improved_places
-WHERE osm_place_geometry.osm_id = improved_places.osm_id;
+WHERE osm_place_point.osm_id = improved_places.osm_id;

--- a/src/import-sql/layers/place_label.sql
+++ b/src/import-sql/layers/place_label.sql
@@ -1,5 +1,5 @@
 CREATE OR REPLACE VIEW place_label_z3 AS (
-    SELECT * FROM osm_place_geometry
+    SELECT * FROM osm_place_point
     WHERE name <> ''
       AND scalerank IS NOT NULL
       AND scalerank BETWEEN 0 AND 2
@@ -7,7 +7,7 @@ CREATE OR REPLACE VIEW place_label_z3 AS (
 );
 
 CREATE OR REPLACE VIEW place_label_z4 AS (
-    SELECT * FROM osm_place_geometry
+    SELECT * FROM osm_place_point
     WHERE name <> ''
       AND scalerank IS NOT NULL
       AND scalerank BETWEEN 0 AND 4
@@ -15,7 +15,7 @@ CREATE OR REPLACE VIEW place_label_z4 AS (
 );
 
 CREATE OR REPLACE VIEW place_label_z5 AS (
-    SELECT * FROM osm_place_geometry
+    SELECT * FROM osm_place_point
     WHERE name <> ''
       AND scalerank IS NOT NULL
       AND scalerank BETWEEN 0 AND 7
@@ -23,7 +23,7 @@ CREATE OR REPLACE VIEW place_label_z5 AS (
 );
 
 CREATE OR REPLACE VIEW place_label_z6toz7 AS (
-    SELECT * FROM osm_place_geometry
+    SELECT * FROM osm_place_point
     WHERE name <> ''
       AND scalerank IS NOT NULL
       AND scalerank BETWEEN 0 AND 10
@@ -31,37 +31,37 @@ CREATE OR REPLACE VIEW place_label_z6toz7 AS (
 );
 
 CREATE OR REPLACE VIEW place_label_z8 AS (
-    SELECT * FROM osm_place_geometry
+    SELECT * FROM osm_place_point
     WHERE name <> ''
       AND type IN ('city', 'town')
 );
 
 CREATE OR REPLACE VIEW place_label_z9 AS (
-    SELECT * FROM osm_place_geometry
+    SELECT * FROM osm_place_point
     WHERE name <> ''
       AND type IN ('island', 'islet', 'aboriginal_lands', 'city', 'town')
 );
 
 CREATE OR REPLACE VIEW place_label_z10 AS (
-    SELECT * FROM osm_place_geometry
+    SELECT * FROM osm_place_point
     WHERE name <> ''
       AND type IN ('island', 'islet', 'aboriginal_lands', 'city', 'town', 'village')
 );
 
 CREATE OR REPLACE VIEW place_label_z11toz12 AS (
-    SELECT * FROM osm_place_geometry
+    SELECT * FROM osm_place_point
     WHERE name <> ''
       AND type IN ('island', 'islet', 'aboriginal_lands', 'city', 'town', 'village', 'suburb')
 );
 
 CREATE OR REPLACE VIEW place_label_z13 AS (
-    SELECT * FROM osm_place_geometry
+    SELECT * FROM osm_place_point
     WHERE name <> ''
       AND type IN ('island', 'islet', 'aboriginal_lands', 'city', 'town', 'village', 'suburb', 'hamlet')
 );
 
 CREATE OR REPLACE VIEW place_label_z14 AS (
-    SELECT * FROM osm_place_geometry
+    SELECT * FROM osm_place_point
     WHERE name <> ''
 );
 

--- a/src/import-sql/tables.yml
+++ b/src/import-sql/tables.yml
@@ -43,7 +43,7 @@ tables:
     buffer: 8
     min_zoom: 5
     max_zoom: 14
-  place_geometry:
+  place_point:
     buffer: 128
     min_zoom: 3
     max_zoom: 14

--- a/tools/mapping-qa-report/report.sql
+++ b/tools/mapping-qa-report/report.sql
@@ -21,7 +21,7 @@ WITH vlayers AS (
   )
   UNION SELECT * FROM compare_layer_feature_count(
     'osm_place_*',
-    array['osm_place_geometry'],
+    array['osm_place_point'],
     array['place_label_layer']
   )
   UNION SELECT * FROM compare_layer_feature_count(


### PR DESCRIPTION
Resolves  #276.
Very easy hack to make the `st_point` faster. Just replace polygon geoms with points as we never need the polygon.

Update on server takes: **20 minutes**

This is easy to keep updated as well.
Because after this update we only have points in the table I also renamed the table to place_points.

```sql
UPDATE osm_place_geometry
SET geometry = topoint(geometry)
WHERE ST_GeometryType(geometry) <> 'ST_Point';
```