### PR TITLE
use_single_id_space in imposm mapping

### DIFF
--- a/osm2vectortiles.tm2source/data.yml
+++ b/osm2vectortiles.tm2source/data.yml
@@ -627,7 +627,7 @@ Layer:
       srid: ''
       table: |-
         (
-        SELECT osm_id_geometry(osm_id, geometry) as osm_id, topoint(geometry) AS geometry,
+        SELECT osm_ids2mbid(osm_id, true) as osm_id, topoint(geometry) AS geometry,
         name,
         coalesce(NULLIF(name_en, ''), name) AS name_en,
         coalesce(NULLIF(name_es, ''), name) AS name_es,

--- a/osm2vectortiles.tm2source/data.yml
+++ b/osm2vectortiles.tm2source/data.yml
@@ -11,21 +11,6 @@ center:
   - 12
 description: |-
   Free global vector tiles from OpenStreetMap compatible with Mapbox Streets v7.
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
   http://osm2vectortiles.org
 Layer: 
   - id: landuse
@@ -43,7 +28,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_id_polygon(osm_id) as osm_id, geometry, landuse_class(type) as class, type
+          SELECT osm_ids2mbid(osm_id, true) as osm_id, geometry, landuse_class(type) as class, type
             FROM (
               SELECT osm_id, geometry, type
               FROM landuse_z5toz8
@@ -95,7 +80,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_id_linestring(osm_id) as osm_id, geometry, type, type as class
+          SELECT osm_ids2mbid(osm_id, false) as osm_id, geometry, type, type as class
           FROM (
             SELECT *
             FROM waterway_z8toz12
@@ -135,7 +120,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_id, geometry
+          SELECT osm_ids2mbid(osm_id, true) AS osm_id, geometry
           FROM (
             SELECT osm_id, geometry
             FROM water_z0
@@ -189,7 +174,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_id_geometry(osm_id, geometry) as osm_id, geometry, type
+          SELECT osm_ids2mbid(osm_id, is_polygon(geometry)) as osm_id, geometry, type
           FROM (
             SELECT *
             FROM aeroway_z9
@@ -224,7 +209,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_id_geometry(osm_id, geometry) as osm_id, geometry, barrier_line_class(type) AS class
+          SELECT osm_ids2mbid(osm_id, is_polygon(geometry)) as osm_id, geometry, barrier_line_class(type) AS class
           FROM barrier_line_z14
           WHERE geometry && !bbox!
             AND z(!scale_denominator!) = 14
@@ -252,7 +237,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_id_polygon(osm_id) as osm_id, geometry, building_is_underground(underground) AS underground
+          SELECT osm_ids2mbid(osm_id, true) as osm_id, geometry, building_is_underground(underground) AS underground
           FROM (
             SELECT osm_id, geometry, underground
             FROM building_z13
@@ -288,7 +273,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_id_polygon(osm_id) AS osm_id, geometry, landuse_overlay_class(type) AS class, type
+          SELECT osm_ids2mbid(osm_id, true) AS osm_id, geometry, landuse_overlay_class(type) AS class, type
           FROM (
             SELECT osm_id, geometry, type FROM landuse_overlay_z5
             WHERE z(!scale_denominator!) = 5
@@ -340,7 +325,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_id_geometry(osm_id, geometry) as osm_id, geometry,
+          SELECT osm_ids2mbid(osm_id, is_polygon(geometry)) as osm_id, geometry,
           road_type(road_class(type, service, access), type, construction, tracktype, service) AS type,
           road_class(type, service, access) AS class, road_oneway(oneway) AS oneway, structure
           FROM (
@@ -397,7 +382,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_id, geometry, admin_level, disputed, maritime
+          SELECT osm_ids2mbid(osm_id, false) AS osm_id, geometry, admin_level, disputed, maritime
           FROM (
             SELECT osm_id, geometry, admin_level, disputed, maritime
             FROM admin_z0
@@ -454,7 +439,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_id_point(osm_id) AS osm_id, wkb_geometry,
+          SELECT osm_ids2mbid(osm_id, true) AS osm_id, wkb_geometry,
           iso3166_1_alpha_2 as code,
           name,
           coalesce(NULLIF(name_en, ''), name) AS name_en,
@@ -528,7 +513,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_id_point(osm_id) as osm_id, wkb_geometry,
+          SELECT osm_ids2mbid(osm_id, true) as osm_id, wkb_geometry,
           name,
           coalesce(NULLIF(name_en, ''), name) AS name_en,
           coalesce(NULLIF(name_es, ''), name) AS name_es,
@@ -592,7 +577,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_id_point(osm_id) as osm_id, wkb_geometry, abbr,
+          SELECT osm_ids2mbid(osm_id, true) as osm_id, wkb_geometry, abbr,
           area_sqkm as area,
           name,
           coalesce(NULLIF(name_en, ''), name) AS name_en,
@@ -726,7 +711,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_id_polygon(osm_id) AS osm_id, geometry AS geometry,
+          SELECT osm_ids2mbid(osm_id, true) AS osm_id, geometry AS geometry,
           name,
           area,
           coalesce(NULLIF(name_en, ''), name) AS name_en,
@@ -783,7 +768,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_id_geometry(osm_id, geometry) AS osm_id, topoint(geometry) AS geometry, ref, name,
+          SELECT osm_ids2mbid(osm_id, true) AS osm_id, topoint(geometry) AS geometry, ref, name,
               coalesce(NULLIF(name_en, ''), name) AS name_en,
               coalesce(NULLIF(name_es, ''), name) AS name_es,
               coalesce(NULLIF(name_fr, ''), name) AS name_fr,
@@ -835,7 +820,7 @@ Layer:
         (
           SELECT * FROM
           (
-          SELECT osm_id_linestring(osm_id) AS osm_id,
+          SELECT osm_ids2mbid(osm_id, false) AS osm_id,
             CASE WHEN z(!scale_denominator!) < 11
                  THEN st_startpoint(geometry)
                  ELSE geometry
@@ -914,7 +899,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_id_linestring(osm_id) AS osm_id, geometry, name,
+          SELECT osm_ids2mbid(osm_id, false) AS osm_id, geometry, name,
           coalesce(NULLIF(name_en, ''), name) AS name_en,
           coalesce(NULLIF(name_es, ''), name) AS name_es,
           coalesce(NULLIF(name_fr, ''), name) AS name_fr,
@@ -966,7 +951,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT topoint(geometry) AS geometry, osm_id_geometry(osm_id, geometry) as osm_id,
+          SELECT topoint(geometry) AS geometry, osm_ids2mbid(osm_id, true) as osm_id,
           name,
           coalesce(NULLIF(name_en, ''), name) AS name_en,
           coalesce(NULLIF(name_es, ''), name) AS name_es,
@@ -1013,7 +998,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT geometry, osm_id_point(osm_id) as osm_id,
+          SELECT geometry, osm_ids2mbid(osm_id, true) as osm_id,
           name,
           coalesce(NULLIF(name_en, ''), name) AS name_en,
           coalesce(NULLIF(name_es, ''), name) AS name_es,
@@ -1063,7 +1048,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_id_point(osm_id) as osm_id, geometry,
+          SELECT osm_ids2mbid(osm_id, true) as osm_id, geometry,
           meter_to_feet(elevation_m) AS elevation_ft,
           elevation_m,
           mountain_peak_type(type) AS maki,
@@ -1110,7 +1095,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_id_geometry(osm_id, geometry) AS osm_id, topoint(geometry) AS geometry, house_num
+          SELECT osm_ids2mbid(osm_id, true) AS osm_id, topoint(geometry) AS geometry, house_num
           FROM housenum_label_z14
           WHERE geometry && !bbox!
             AND z(!scale_denominator!) = 14

--- a/src/import-osm/mapping.yml
+++ b/src/import-osm/mapping.yml
@@ -1,3 +1,4 @@
+use_single_id_space: true
 generalized_tables:
   landuse_polygon_gen0:
     source: landuse_polygon_gen1

--- a/src/import-sql/functions.sql
+++ b/src/import-sql/functions.sql
@@ -74,7 +74,7 @@ CREATE OR REPLACE FUNCTION osm_id_linestring(osm_id BIGINT) RETURNS BIGINT AS $$
 BEGIN
     RETURN CASE
         WHEN transform_osm_id(osm_id) >= 0 THEN (transform_osm_id(osm_id) * 10) + 1
-        ELSE (transform_osm_id(osm_id) * 10) + 3
+        ELSE (abs(transform_osm_id(osm_id)) * 10) + 3
     END;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
@@ -85,7 +85,7 @@ CREATE OR REPLACE FUNCTION osm_id_polygon(osm_id BIGINT) RETURNS BIGINT AS $$
 BEGIN
     RETURN CASE
         WHEN transform_osm_id(osm_id) >= 0 THEN (transform_osm_id(osm_id) * 10) + 2
-        ELSE (transform_osm_id(osm_id) * 10) + 4
+        ELSE (abs(transform_osm_id(osm_id)) * 10) + 4
     END;
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;

--- a/src/import-sql/functions.sql
+++ b/src/import-sql/functions.sql
@@ -52,57 +52,6 @@ $$ LANGUAGE plpgsql;
 
 -- OSM ID transformations
 
--- Reproject the osm id from the imposm3 single id space into the normal imposm3 id space
-CREATE OR REPLACE FUNCTION transform_osm_id(osm_id BIGINT) RETURNS BIGINT AS $$
-BEGIN
-    RETURN CASE
-        WHEN osm_id < -1e17 THEN osm_id + 1e17
-        WHEN osm_id BETWEEN -1e17 AND 0 THEN ABS(osm_id)
-        ELSE osm_id
-    END;
-END;
-$$ LANGUAGE plpgsql IMMUTABLE;
-
-CREATE OR REPLACE FUNCTION osm_id_point(osm_id BIGINT) RETURNS BIGINT AS $$
-BEGIN
-    RETURN (osm_id * 10);
-END;
-$$ LANGUAGE plpgsql IMMUTABLE;
-
--- Handle normal ways (positive osm ids) and ways from relations (negative osm ids)
-CREATE OR REPLACE FUNCTION osm_id_linestring(osm_id BIGINT) RETURNS BIGINT AS $$
-BEGIN
-    RETURN CASE
-        WHEN transform_osm_id(osm_id) >= 0 THEN (transform_osm_id(osm_id) * 10) + 1
-        ELSE (abs(transform_osm_id(osm_id)) * 10) + 3
-    END;
-END;
-$$ LANGUAGE plpgsql IMMUTABLE;
-
--- Handle constructed polygons from ways (positive osm ids) and
--- polygons from relations (negative osm ids)
-CREATE OR REPLACE FUNCTION osm_id_polygon(osm_id BIGINT) RETURNS BIGINT AS $$
-BEGIN
-    RETURN CASE
-        WHEN transform_osm_id(osm_id) >= 0 THEN (transform_osm_id(osm_id) * 10) + 2
-        ELSE (abs(transform_osm_id(osm_id)) * 10) + 4
-    END;
-END;
-$$ LANGUAGE plpgsql IMMUTABLE;
-
--- Determine osm_id based on geometry type and choose the appropriate osm_id function
-CREATE OR REPLACE FUNCTION osm_id_geometry(osm_id BIGINT, geom geometry) RETURNS BIGINT AS $$
-BEGIN RETURN CASE
-        WHEN ST_GeometryType(geom) IN ('ST_LineString', 'ST_MultiLineString') THEN osm_id_linestring(osm_id)
-        WHEN ST_GeometryType(geom) IN ('ST_Point', 'ST_MultiPoint') THEN osm_id_point(osm_id)
-        WHEN ST_GeometryType(geom) IN ('ST_Polygon', 'ST_MultiPolygon') THEN osm_id_polygon(osm_id)
-        ELSE osm_id_point(osm_id)
-      END;
-END;
-$$ LANGUAGE plpgsql IMMUTABLE;
-
-
-
 -- specification : https://www.mapbox.com/vector-tiles/mapbox-streets-v7/
 -- osm_ids :  imposm3 with use_single_id_space:true
 CREATE OR REPLACE FUNCTION osm_ids2mbid (osm_ids BIGINT, is_polygon bool ) RETURNS BIGINT AS $$
@@ -112,7 +61,7 @@ BEGIN
    WHEN (NOT is_polygon) AND (osm_ids >= -1e17 ) AND (osm_ids < 0 ) THEN ( (abs(osm_ids)      ) * 10) + 1   -- +1 way linestring
    WHEN (    is_polygon) AND (osm_ids >= -1e17 ) AND (osm_ids < 0 ) THEN ( (abs(osm_ids)      ) * 10) + 2   -- +2 way poly
    WHEN (NOT is_polygon) AND (osm_ids <  -1e17 )                    THEN ( (abs(osm_ids) -1e17) * 10) + 3   -- +3 relations linestring
-   WHEN (    is_polygon) AND (osm_ids <  -1e17 )                    THEN ( (abs(osm_ids) -1e17) * 10) + 4   -- +3 relations poly
+   WHEN (    is_polygon) AND (osm_ids <  -1e17 )                    THEN ( (abs(osm_ids) -1e17) * 10) + 4   -- +4 relations poly
    ELSE 0
  END;
 END;
@@ -120,10 +69,8 @@ $$ LANGUAGE plpgsql IMMUTABLE;
 
 
 CREATE OR REPLACE FUNCTION is_polygon( geom geometry) RETURNS bool AS $$
-BEGIN RETURN CASE
-        WHEN ST_GeometryType(geom) IN ('ST_Polygon', 'ST_MultiPolygon') THEN true
-        ELSE false
-      END;
+BEGIN
+    RETURN ST_GeometryType(geom) IN ('ST_Polygon', 'ST_MultiPolygon');
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 


### PR DESCRIPTION
Resolves #281 

Only possible thanks to the research of @ImreSamu in #281.

*This is how I understand it, please correct me @ImreSamu *
`use_single_id_space=true` will divides the id range up into three ranges.

`id < - 1e17`: Ways
`0 < id > - 1e17 `: Relations
`id > 0`: Points

What I can do now is to map the relations back into the negative range (by adding `1e17`).
And ways back to the positive range (by making them absolute). And then the functions we created previously (`osm_id_linestring`, `osm_id_polygon`, `osm_id_point`, `osm_id_geometry` handle the rest because they make the decision based on geometry type and whether it originated from a relation.

![drawing](https://cloud.githubusercontent.com/assets/1288339/14785378/c1159c5e-0afa-11e6-8c80-a8f2cad8ceb9.png)

