### PR TITLE
Exclude boundary=administrative where tag natural=coastline is set

### DIFF
--- a/src/import-osm/mapping.yml
+++ b/src/import-osm/mapping.yml
@@ -31,9 +31,6 @@ tables:
     - name: maritime
       type: boolint
       key: maritime
-    - name: natural
-      type: string
-      key: natural
     - name: area
       type: pseudoarea
     filters:

--- a/src/import-osm/mapping.yml
+++ b/src/import-osm/mapping.yml
@@ -31,6 +31,9 @@ tables:
     - name: maritime
       type: boolint
       key: maritime
+    - name: natural
+      type: string
+      key: natural
     - name: area
       type: pseudoarea
     filters:
@@ -43,6 +46,7 @@ tables:
       - [ "admin_level", "8" ]
       - [ "admin_level", "9" ]
       - [ "admin_level", "10" ]
+      - [ "natural", "coastline" ]
     mapping:
       boundary:
       - administrative


### PR DESCRIPTION
Found a coastline bug in dänemark. If a boundary=administrative as additionally tagged as natural=coastline the boundary should not be imported.

![openstreetmap___linie__4125988](https://cloud.githubusercontent.com/assets/1810384/14882975/d394ac42-0d3b-11e6-8e60-ee7d13bc4b63.png)

Before:
![compare_open_streets_with_mapbox_streets](https://cloud.githubusercontent.com/assets/1810384/14883021/1e646dc0-0d3c-11e6-813f-705fe07b97db.png)

After:
![compare_open_streets_with_mapbox_streets](https://cloud.githubusercontent.com/assets/1810384/14882890/5ddceac8-0d3b-11e6-9d76-dbd41fa30836.png)

@lukasmartinelli @ImreSamu Used a filter to exclude everything tagged with natural=coastline. Does the filter key need to be included as a column?

```sql
- name: natural
  type: string
  key: natural
```