### PR TITLE
Cosmetics for ocean polygons

### DIFF
--- a/src/import-external/import-water.sh
+++ b/src/import-external/import-water.sh
@@ -12,12 +12,12 @@ source sql.sh
 function import_shp() {
 	local shp_file=$1
 	local table_name=$2
-	shp2pgsql -I -g way "$shp_file" "$table_name" | exec_psql | hide_inserts
+	shp2pgsql -s 3857 -I -g geometry "$shp_file" "$table_name" | exec_psql | hide_inserts
 }
 
 function import_water() {
-    local table_name="osm_ocean_polygons"
-    local simplified_table_name="osm_ocean_polygons_gen0"
+    local table_name="osm_ocean_polygon"
+    local simplified_table_name="osm_ocean_polygon_gen0"
 
     drop_table "$table_name"
     import_shp "$WATER_POLYGONS_FILE" "$table_name"

--- a/src/import-sql/layers/water.sql
+++ b/src/import-sql/layers/water.sql
@@ -20,37 +20,37 @@ CREATE OR REPLACE VIEW water_z2toz3 AS
     FROM ne_50m_lakes;
 
 CREATE OR REPLACE VIEW water_z4 AS
-    SELECT 0 AS osm_id, way AS geometry
-    FROM osm_ocean_polygons_gen0
+    SELECT 0 AS osm_id, geometry
+    FROM osm_ocean_polygon_gen0
     UNION ALL
     SELECT 0 AS osm_id, geom AS geometry
     FROM ne_10m_lakes;
 
 CREATE OR REPLACE VIEW water_z5toz7 AS
-    SELECT 0 AS osm_id, way AS geometry
-    FROM osm_ocean_polygons_gen0
+    SELECT 0 AS osm_id, geometry
+    FROM osm_ocean_polygon_gen0
     UNION ALL
     SELECT osm_id, geometry
     FROM osm_water_polygon_gen1;
 
 CREATE OR REPLACE VIEW water_z8toz10 AS
-    SELECT 0 AS osm_id, way AS geometry
-    FROM osm_ocean_polygons
+    SELECT 0 AS osm_id, geometry
+    FROM osm_ocean_polygon
     UNION ALL
     SELECT osm_id, geometry
     FROM osm_water_polygon_gen1;
 
 CREATE OR REPLACE VIEW water_z11toz12 AS
-    SELECT 0 AS osm_id, way AS geometry, 0 AS area
-    FROM osm_ocean_polygons
+    SELECT 0 AS osm_id, geometry, 0 AS area
+    FROM osm_ocean_polygon
     UNION ALL
     SELECT osm_id, geometry, area
     FROM osm_water_polygon
     WHERE area >= 15000;
 
 CREATE OR REPLACE VIEW water_z13toz14 AS
-    SELECT 0 AS osm_id, way AS geometry
-    FROM osm_ocean_polygons
+    SELECT 0 AS osm_id, geometry
+    FROM osm_ocean_polygon
     UNION ALL
     SELECT osm_id, geometry
     FROM osm_water_polygon;


### PR DESCRIPTION
- Sets SRID to 3857 (mercator) during import
- Renames the column from way to geometry
- Renames the table name to polygon instead of polygons

**The build will always fail because the prebuild import-external container based on master branch is used**