### PR TITLE
ST_Centroid instead of ST_PointOnSurface for less important labels

### DIFF
--- a/osm2vectortiles.tm2source/data.yml
+++ b/osm2vectortiles.tm2source/data.yml
@@ -787,7 +787,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_ids2mbid(osm_id, true) AS osm_id, ST_Centroid(geometry) AS geometry, ref, name,
+          SELECT osm_ids2mbid(osm_id, true) AS osm_id, topoint(geometry) AS geometry, ref, name,
               coalesce(NULLIF(name_en, ''), name) AS name_en,
               coalesce(NULLIF(name_es, ''), name) AS name_es,
               coalesce(NULLIF(name_fr, ''), name) AS name_fr,
@@ -1111,7 +1111,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_ids2mbid(osm_id, true) AS osm_id, ST_Centroid(geometry) AS geometry, house_num
+          SELECT osm_ids2mbid(osm_id, true) AS osm_id, topoint(geometry) AS geometry, house_num
           FROM housenum_label_z14
           WHERE geometry && !bbox!
             AND z(!scale_denominator!) = 14

--- a/osm2vectortiles.tm2source/data.yml
+++ b/osm2vectortiles.tm2source/data.yml
@@ -1111,7 +1111,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_ids2mbid(osm_id, true) AS osm_id, topoint(geometry) AS geometry, house_num
+          SELECT osm_ids2mbid(osm_id, true) AS osm_id, ST_Centroid(geometry) AS geometry, house_num
           FROM housenum_label_z14
           WHERE geometry && !bbox!
             AND z(!scale_denominator!) = 14

--- a/osm2vectortiles.tm2source/data.yml
+++ b/osm2vectortiles.tm2source/data.yml
@@ -787,7 +787,7 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_ids2mbid(osm_id, true) AS osm_id, topoint(geometry) AS geometry, ref, name,
+          SELECT osm_ids2mbid(osm_id, true) AS osm_id, ST_Centroid(geometry) AS geometry, ref, name,
               coalesce(NULLIF(name_en, ''), name) AS name_en,
               coalesce(NULLIF(name_es, ''), name) AS name_es,
               coalesce(NULLIF(name_fr, ''), name) AS name_fr,

--- a/src/import-osm/import.sh
+++ b/src/import-osm/import.sh
@@ -39,7 +39,7 @@ function import_pbf() {
     create_osm_water_point_table
 
     echo "Update osm_place_polygon with point geometry"
-    update_place_point
+    update_points
 
     echo "Update scaleranks from Natural Earth data"
     update_scaleranks
@@ -53,8 +53,8 @@ function extract_timestamp() {
     osmconvert "$file" --out-timestamp
 }
 
-function update_place_point() {
-    exec_sql_file "place_point_update.sql"
+function update_points() {
+    exec_sql_file "point_update.sql"
 }
 
 function update_scaleranks() {
@@ -172,7 +172,7 @@ function import_pbf_diffs() {
     create_osm_water_point_table
 
     echo "Update osm_place_polygon with point geometry"
-    update_place_point
+    update_points
 
     local timestamp=$(extract_timestamp "$diffs_file")
     echo "Set $timestamp for latest updates from $diffs_file"

--- a/src/import-osm/place_point_update.sql
+++ b/src/import-osm/place_point_update.sql
@@ -1,3 +1,0 @@
-UPDATE osm_place_point
-SET geometry = topoint(geometry)
-WHERE ST_GeometryType(geometry) <> 'ST_Point';

--- a/src/import-osm/point_update.sql
+++ b/src/import-osm/point_update.sql
@@ -1,0 +1,11 @@
+UPDATE osm_place_point
+SET geometry = topoint(geometry)
+WHERE ST_GeometryType(geometry) <> 'ST_Point';
+
+UPDATE osm_poi_polygon
+SET geometry = topoint(geometry)
+WHERE ST_GeometryType(geometry) <> 'ST_Point';
+
+UPDATE osm_housenumber_polygon
+SET geometry = topoint(geometry)
+WHERE ST_GeometryType(geometry) <> 'ST_Point';


### PR DESCRIPTION
As @manuelroth suggested in #284 we should optimize label placement for housenumbers and poi labels as well. Calculating the point on surface for housenumbers and po labels can take up to 12seconds if we replace `ST_PointOnSurface` with `ST_Centroid` (@sfkeller suggested this when label placement is not that important) this comes down to 100ms.

Therefore I propose that we speed up the label placement (at the cost of possible bad labels) for
- POI labels
- Housenumbers

For POI labels this is not a huge problem since most POIs are already points but for housenumber there might be certain cases where it is no longer as beautiful as with `ST_PointOnSurface`.

![drawing 1](https://cloud.githubusercontent.com/assets/1288339/14948233/66b6a886-103e-11e6-8e57-9988dbe1d7ca.png)

But housenumbers are something that occur in masses perhaps the best possible label placement is no longer that important. The clear important case for `ST_PointOnSurface` are water labels imho since it really does look ugly if the Lake of Zurich label is somewhere on land.

We cannot use the same trick as for place labels (where we turn all geometries into points before hand) without creating a new table just for housenum labels (which will also take a huge amount of time when importing).

Would be glad for feedback from @manuelroth and @sfkeller whether it is worth to sacrifice some cartographic beauty for the gain of a 20 to 100x speedup. I do think so since housenumber and poi labels are not that critical and it is rather a rare case where ST_PointOnSurface is really used.
