### PR TITLE
Additional osm data (landuse={residential, commercial, retail, railway, industrial, military})

### DIFF
--- a/osm2vectortiles.tm2source/data.yml
+++ b/osm2vectortiles.tm2source/data.yml
@@ -29,9 +29,16 @@ Layer:
       table: |-
         (
           SELECT osm_ids2mbid(MAX(osm_id), true) AS osm_id, ST_CollectionExtract(ST_Collect(geometry), 3) AS geometry, landuse_class(type) AS class, type
-          FROM landuse_z5toz8
-          WHERE z(!scale_denominator!) BETWEEN 5 AND 8
-            AND geometry && !bbox!
+          FROM (
+            SELECT osm_id, geometry, type
+            FROM landuse_z5toz7
+            WHERE z(!scale_denominator!) BETWEEN 5 AND 7
+            UNION ALL
+            SELECT osm_id, geometry, type
+            FROM landuse_z8
+            WHERE z(!scale_denominator!) = 8
+          ) AS landuse_z5toz8
+          WHERE geometry && !bbox!
           GROUP BY type
           UNION ALL
           SELECT osm_ids2mbid(osm_id, true) AS osm_id, geometry, landuse_class(type) AS class, type
@@ -55,7 +62,7 @@ Layer:
               SELECT osm_id, geometry, type
               FROM landuse_z13toz14
               WHERE z(!scale_denominator!) BETWEEN 13 AND 14
-            ) AS landuse
+            ) AS landuse_z9toz14
             WHERE geometry && !bbox!
         ) AS data
       type: postgis

--- a/osm2vectortiles.tm2source/data.yml
+++ b/osm2vectortiles.tm2source/data.yml
@@ -31,12 +31,12 @@ Layer:
           SELECT osm_ids2mbid(MAX(osm_id), true) AS osm_id, ST_CollectionExtract(ST_Collect(geometry), 3) AS geometry, landuse_class(type) AS class, type
           FROM (
             SELECT osm_id, geometry, type
-            FROM landuse_z5toz7
-            WHERE z(!scale_denominator!) BETWEEN 5 AND 7
+            FROM landuse_z5toz6
+            WHERE z(!scale_denominator!) BETWEEN 5 AND 6
             UNION ALL
             SELECT osm_id, geometry, type
-            FROM landuse_z8
-            WHERE z(!scale_denominator!) = 8
+            FROM landuse_z7toz8
+            WHERE z(!scale_denominator!) BETWEEN 7 AND 8
           ) AS landuse_z5toz8
           WHERE geometry && !bbox!
           GROUP BY type

--- a/src/import-sql/layers/landuse.sql
+++ b/src/import-sql/layers/landuse.sql
@@ -1,30 +1,35 @@
-CREATE OR REPLACE VIEW landuse_z5toz8 AS
+CREATE OR REPLACE VIEW landuse_z5toz7 AS
     SELECT osm_id, geometry, type
     FROM osm_landuse_polygon_gen0
     WHERE type IN ('wood', 'forest');
 
+CREATE OR REPLACE VIEW landuse_z8 AS
+    SELECT osm_id, geometry, type
+    FROM osm_landuse_polygon_gen0
+    WHERE type IN ('wood', 'forest', 'residential');
+
 CREATE OR REPLACE VIEW landuse_z9 AS
     SELECT *
     FROM osm_landuse_polygon_gen0
-    WHERE landuse_class(type) IN ('wood', 'grass', 'cemetery', 'park', 'school')
+    WHERE landuse_class(type) IN ('wood', 'forest', 'residential', 'grass', 'cemetery', 'park', 'school')
       AND st_area(geometry) > 500000;
 
 CREATE OR REPLACE VIEW landuse_z10 AS
     SELECT *
     FROM osm_landuse_polygon_gen0
-    WHERE landuse_class(type) IN ('wood', 'grass', 'cemetery', 'park', 'school')
+    WHERE landuse_class(type) IN ('wood', 'forest', 'residential', 'grass', 'cemetery', 'park', 'school')
       AND st_area(geometry) > 99000;
 
 CREATE OR REPLACE VIEW landuse_z11 AS
     SELECT *
     FROM osm_landuse_polygon_gen1
-    WHERE landuse_class(type) IN ('wood', 'grass', 'cemetery', 'park', 'school', 'hospital')
+    WHERE landuse_class(type) IN ('wood', 'forest', 'residential', 'grass', 'cemetery', 'park', 'school', 'hospital')
       AND st_area(geometry) > 50000;
 
 CREATE OR REPLACE VIEW landuse_z12 AS
     SELECT *
     FROM osm_landuse_polygon
-    WHERE landuse_class(type) IN ('wood', 'grass', 'cemetery', 'park', 'school', 'hospital')
+    WHERE landuse_class(type) IN ('wood', 'forest', 'residential', 'grass', 'cemetery', 'park', 'school', 'hospital')
       AND st_area(geometry) > 10000;
 
 CREATE OR REPLACE VIEW landuse_z13toz14 AS
@@ -33,7 +38,9 @@ CREATE OR REPLACE VIEW landuse_z13toz14 AS
     WHERE type NOT IN ('wetland', 'marsh', 'swamp', 'bog', 'mud', 'tidalflat', 'national_park', 'nature_reserve', 'protected_area');
 
 CREATE OR REPLACE VIEW landuse_layer AS (
-    SELECT osm_id FROM landuse_z5toz8
+    SELECT osm_id FROM landuse_z5toz7
+    UNION
+    SELECT osm_id FROM landuse_z8
     UNION
     SELECT osm_id FROM landuse_z9
     UNION

--- a/src/import-sql/layers/landuse.sql
+++ b/src/import-sql/layers/landuse.sql
@@ -1,12 +1,13 @@
-CREATE OR REPLACE VIEW landuse_z5toz7 AS
+CREATE OR REPLACE VIEW landuse_z5toz6 AS
     SELECT osm_id, geometry, type
     FROM osm_landuse_polygon_gen0
     WHERE type IN ('wood', 'forest');
 
-CREATE OR REPLACE VIEW landuse_z8 AS
+CREATE OR REPLACE VIEW landuse_z7toz8 AS
     SELECT osm_id, geometry, type
     FROM osm_landuse_polygon_gen0
-    WHERE type IN ('wood', 'forest', 'residential');
+    WHERE type IN ('wood', 'forest', 'residential')
+      AND st_area(geometry) > 1000000;
 
 CREATE OR REPLACE VIEW landuse_z9 AS
     SELECT *
@@ -17,19 +18,19 @@ CREATE OR REPLACE VIEW landuse_z9 AS
 CREATE OR REPLACE VIEW landuse_z10 AS
     SELECT *
     FROM osm_landuse_polygon_gen0
-    WHERE landuse_class(type) IN ('wood', 'forest', 'residential', 'grass', 'cemetery', 'park', 'school')
+    WHERE landuse_class(type) IN ('wood', 'forest', 'residential', 'commercial', 'retail', 'railway', 'industrial', 'grass', 'cemetery', 'park', 'school')
       AND st_area(geometry) > 99000;
 
 CREATE OR REPLACE VIEW landuse_z11 AS
     SELECT *
     FROM osm_landuse_polygon_gen1
-    WHERE landuse_class(type) IN ('wood', 'forest', 'residential', 'grass', 'cemetery', 'park', 'school', 'hospital')
+    WHERE landuse_class(type) IN ('wood', 'forest', 'residential','commercial', 'retail', 'railway', 'industrial', 'military', 'grass', 'cemetery', 'park', 'school', 'hospital')
       AND st_area(geometry) > 50000;
 
 CREATE OR REPLACE VIEW landuse_z12 AS
     SELECT *
     FROM osm_landuse_polygon
-    WHERE landuse_class(type) IN ('wood', 'forest', 'residential', 'grass', 'cemetery', 'park', 'school', 'hospital')
+    WHERE landuse_class(type) IN ('wood', 'forest', 'residential', 'grass','retail', 'railway', 'industrial', 'military', 'cemetery', 'park', 'school', 'hospital')
       AND st_area(geometry) > 10000;
 
 CREATE OR REPLACE VIEW landuse_z13toz14 AS
@@ -38,9 +39,9 @@ CREATE OR REPLACE VIEW landuse_z13toz14 AS
     WHERE type NOT IN ('wetland', 'marsh', 'swamp', 'bog', 'mud', 'tidalflat', 'national_park', 'nature_reserve', 'protected_area');
 
 CREATE OR REPLACE VIEW landuse_layer AS (
-    SELECT osm_id FROM landuse_z5toz7
+    SELECT osm_id FROM landuse_z5toz6
     UNION
-    SELECT osm_id FROM landuse_z8
+    SELECT osm_id FROM landuse_z7toz8
     UNION
     SELECT osm_id FROM landuse_z9
     UNION


### PR DESCRIPTION
- Resolves #307 
- As suggested in #307 the additional landuse data is present in the vector tiles as following:
  - z7-z14: residential
  - z10-z14: commercial, retail, railway, industrial
  - z11-z14: military
- Style example (both type and class have the same value): 
```
{
    "id": "landuse_residential",
    "type": "fill",
    "metadata": {
        "mapbox:group": "1444849388993.3071"
    },
    "source": "mapbox",
    "source-layer": "landuse",
    "interactive": true,
    "filter": [
        "==",
        "class",
        "residential"
    ],
    "paint": {
        "fill-color": "#d3d3d3"
    }
}
```
- The impact on size is minimal, as the data gets filtered by area like forest and wood. Check it with the tile-inspector.