### PR TITLE
Stability and Performance Improvements

### DIFF
--- a/osm2vectortiles.tm2source/data.yml
+++ b/osm2vectortiles.tm2source/data.yml
@@ -43,7 +43,7 @@ Layer:
           UNION ALL
           SELECT
             osm_ids2mbid(osm_id, true) AS osm_id,
-            CASE WHEN ST_Area(geometry) > 10000000 AND z(!scale_denominator!) >= 12
+            CASE WHEN ST_Area(geometry) > 10000000
                  THEN ST_Intersection(ST_MakeValid(geometry), !bbox!)
                  ELSE geometry
             END AS geometry,
@@ -141,7 +141,7 @@ Layer:
         (
           SELECT
             osm_ids2mbid(osm_id, true) AS osm_id,
-            CASE WHEN ST_Area(geometry) > 10000000 AND z(!scale_denominator!) >= 12 AND osm_id <> 0
+            CASE WHEN ST_Area(geometry) > 10000000 AND osm_id <> 0
                  THEN ST_Intersection(ST_MakeValid(geometry), !bbox!)
                  ELSE geometry
             END AS geometry
@@ -303,7 +303,7 @@ Layer:
         (
           SELECT
             osm_ids2mbid(osm_id, true) AS osm_id,
-            CASE WHEN ST_Area(geometry) > 10000000 AND z(!scale_denominator!) >= 12
+            CASE WHEN ST_Area(geometry) > 10000000
                  THEN ST_Intersection(ST_MakeValid(geometry), !bbox!)
                  ELSE geometry
             END AS geometry,

--- a/osm2vectortiles.tm2source/data.yml
+++ b/osm2vectortiles.tm2source/data.yml
@@ -41,7 +41,13 @@ Layer:
           WHERE geometry && !bbox!
           GROUP BY type
           UNION ALL
-          SELECT osm_ids2mbid(osm_id, true) AS osm_id, geometry, landuse_class(type) AS class, type
+          SELECT
+            osm_ids2mbid(osm_id, true) AS osm_id,
+            CASE WHEN ST_Area(geometry) > 10000000 AND z(!scale_denominator!) >= 12
+                 THEN ST_Intersection(ST_MakeValid(geometry), !bbox!)
+                 ELSE geometry
+            END AS geometry,
+            landuse_class(type) AS class, type
             FROM (
               SELECT osm_id, geometry, type
               FROM landuse_z9
@@ -133,7 +139,12 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_ids2mbid(osm_id, true) AS osm_id, geometry
+          SELECT
+            osm_ids2mbid(osm_id, true) AS osm_id,
+            CASE WHEN ST_Area(geometry) > 10000000 AND z(!scale_denominator!) >= 12 AND osm_id <> 0
+                 THEN ST_Intersection(ST_MakeValid(geometry), !bbox!)
+                 ELSE geometry
+            END AS geometry
           FROM (
             SELECT osm_id, geometry
             FROM water_z0
@@ -290,7 +301,13 @@ Layer:
       srid: ''
       table: |-
         (
-          SELECT osm_ids2mbid(osm_id, true) AS osm_id, geometry, landuse_overlay_class(type) AS class, type
+          SELECT
+            osm_ids2mbid(osm_id, true) AS osm_id,
+            CASE WHEN ST_Area(geometry) > 10000000 AND z(!scale_denominator!) >= 12
+                 THEN ST_Intersection(ST_MakeValid(geometry), !bbox!)
+                 ELSE geometry
+            END AS geometry,
+            landuse_overlay_class(type) AS class, type
           FROM (
             SELECT osm_id, geometry, type FROM landuse_overlay_z5
             WHERE z(!scale_denominator!) = 5

--- a/src/export/Dockerfile
+++ b/src/export/Dockerfile
@@ -19,6 +19,7 @@ RUN npm -g outdated | grep -v npm
 RUN apt-get update && apt-get install -y --no-install-recommends \
         python \
         python-pip \
+        python-dev \
     && rm -rf /var/lib/apt/lists/
 
 VOLUME /data/tm2source /data/export

--- a/src/export/export_remote.py
+++ b/src/export/export_remote.py
@@ -176,6 +176,7 @@ def export_remote(tm2source, rabbitmq_url, queue_name, result_queue_name,
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             durable_publish(channel, failed_queue_name, body=body)
             channel.basic_ack(delivery_tag=method.delivery_tag)
+            channel.stop_consuming()
             time.sleep(5)  # Give RabbitMQ some time
             raise e
 

--- a/src/export/export_remote.py
+++ b/src/export/export_remote.py
@@ -150,10 +150,10 @@ def export_remote(tm2source, rabbitmq_url, queue_name, result_queue_name,
 
         try:
             subprocess.check_call(tilelive_cmd)
-        except subprocess.CalledProcessError:
+        except subprocess.CalledProcessError as e:
             durable_publish(channel, failed_queue_name, body=body)
             channel.basic_ack(delivery_tag=method.delivery_tag)
-            return
+            raise e
 
         end = time.time()
 

--- a/src/export/export_remote.py
+++ b/src/export/export_remote.py
@@ -190,6 +190,7 @@ def configure_rabbitmq(channel):
         return channel.queue_declare(queue=queue, durable=True)
 
     queue_declare('jobs')
+    queue_declare('failed-jobs')
     queue_declare('results')
 
 

--- a/src/export/requirements.txt
+++ b/src/export/requirements.txt
@@ -2,5 +2,6 @@ docopt==0.6.2
 boto==2.38.0
 pika==0.10.0
 humanize==0.5.1
+subprocess32==3.2.7
 -e git+https://github.com/lukasmartinelli/mbtoolbox.git@#egg=mbtoolbox
 -e git+https://github.com/mapbox/mbutil.git@#egg=mbutil-0.2.0beta

--- a/src/import-osm/mapping.yml
+++ b/src/import-osm/mapping.yml
@@ -321,7 +321,7 @@ tables:
     - name: id
       type: id
     - name: geometry
-      type: geometry
+      type: validated_geometry
     - name: timestamp
       type: pbf_timestamp
     - name: type
@@ -680,7 +680,7 @@ tables:
     - name: id
       type: id
     - name: geometry
-      type: geometry
+      type: validated_geometry
     - name: timestamp
       type: pbf_timestamp
     - key: name

--- a/src/import-sql/triggers.sql
+++ b/src/import-sql/triggers.sql
@@ -150,7 +150,7 @@ BEGIN
         UNION
         SELECT * FROM osm_tables_delete
     LOOP
-        EXECUTE format('DROP TABLE %I CASCADE', t.table_name);
+        EXECUTE format('DROP TABLE IF EXISTS %I CASCADE', t.table_name);
     END LOOP;
 END;
 $$ language plpgsql;

--- a/src/merge-jobs/merge-jobs.py
+++ b/src/merge-jobs/merge-jobs.py
@@ -69,6 +69,8 @@ def merge_results(rabbitmq_url, merge_target, result_queue_name):
 
     connection = pika.BlockingConnection(pika.URLParameters(rabbitmq_url))
     channel = connection.channel()
+    channel.basic_qos(prefetch_count=3)
+    channel.confirm_delivery()
 
     def callback(ch, method, properties, body):
         msg = json.loads(body.decode('utf-8'))


### PR DESCRIPTION
These are things that work well in the world rendering and helped to solve some problems from #251 

- Fail fast and deal with bad tiles later! 
  - Have low copy timeout (not high as I initially thought)
  - Have a process timeout 98d19b8
  - Have a `failed-jobs` queue (Avoid having the bad tile jobs always requeueing)
- Simplified geometries might be invalid. Fix them first `ST_MakeValid` 06243fb
- Low prefetch count in merging since it is not that fast (`1/s`) 7c440c8
- Clip large polygons with `ST_Intersection` when requested by Mapnik 1d09caa
  - Causes more CPU overhead to DB
