### PR TITLE
Calculate quad key externally

### DIFF
--- a/src/generate-jobs/calculate_quad_key.py
+++ b/src/generate-jobs/calculate_quad_key.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+"""Calculate QuadKey for TSV file and append it as column
+
+Usage:
+  calculate_quad_key.py <list_file>
+  calculate_quad_key.py (-h | --help)
+  calculate_quad_key.py --version
+
+Options:
+  -h --help                    Show this screen.
+  --version                    Show version.
+"""
+import system
+import csv
+from docopt import docopt
+
+
+def quad_tree(tx, ty, zoom):
+    """
+    Converts XYZ tile coordinates to Microsoft QuadTree
+    http://www.maptiler.org/google-maps-coordinates-tile-bounds-projection/
+    """
+    quad_key = ''
+    for i in range(zoom, 0, -1):
+        digit = 0
+        mask = 1 << (i-1)
+        if (tx & mask) != 0:
+            digit += 1
+        if (ty & mask) != 0:
+            digit += 2
+        quad_key += str(digit)
+
+    return quad_key
+
+
+if __name__ == '__main__':
+    args = docopt(__doc__, version='0.1')
+
+    writer = csv.writer(system.out)
+    with open(args['<list_file>'], "r") as file_handle:
+        for line in file_handle:
+            z, x, y = line.split('/')
+
+            writer.writerow([
+                line,
+                quad_tree(int(x), int(y), int(z))]
+            )

--- a/src/generate-jobs/generate_jobs.py
+++ b/src/generate-jobs/generate_jobs.py
@@ -110,24 +110,6 @@ def pyramid_jobs(x, y, z, job_zoom):
                                  max_zoom=14, bounds=bounds)
 
 
-def quad_tree(tx, ty, zoom):
-    """
-    Converts XYZ tile coordinates to Microsoft QuadTree
-    http://www.maptiler.org/google-maps-coordinates-tile-bounds-projection/
-    """
-    quad_key = ''
-    for i in range(zoom, 0, -1):
-        digit = 0
-        mask = 1 << (i-1)
-        if (tx & mask) != 0:
-            digit += 1
-        if (ty & mask) != 0:
-            digit += 2
-        quad_key  += str(digit)
-
-    return quad_key
-
-
 if __name__ == '__main__':
     args = docopt(__doc__, version='0.1')
 
@@ -146,18 +128,10 @@ if __name__ == '__main__':
 
         def convert_line_to_tile(line):
             z, x, y = line.split('/')
-            return {
-                'x': int(x),
-                'y': int(y),
-                'z': int(z)
-            }
+            return { 'x': int(x), 'y': int(y), 'z': int(z) }
 
         with open(args['<list_file>'], "r") as file_handle:
-            tiles = [convert_line_to_tile(l) for l in file_handle]
-
-            # Sorting the tiles should result in besser job
-            # locality when dividing it into batches
-            tiles.sort(key=lambda t: quad_tree(t['z'], t['x'], t['y']))
+            tiles = (convert_line_to_tile(l) for l in file_handle)
 
             for job in split_tiles_into_batch_jobs(tiles, batch_size):
                 print(json.dumps(job), flush=True)


### PR DESCRIPTION
We cannot sort the tiles by quad key in memory (since the tiles do not fit into memory - heap grows to 60GB in Python).
Instead of implementing an external merge sort myself now you can calculate the quad key before and then use UNIX sort to sort them (which is amazingly fast) and then feed it into the `generate_jobs.py` script.