### PR TITLE
add import and export dirs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ __pycache__/
 *$py.class
 
 # Data files
+import/
+export/
 *.mbtiles
 *.pbf
 *.gz


### PR DESCRIPTION
The newly created import and export directories should be in .gitignore.