### PR TITLE
Ability to disable diff-mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ import-osm:
   links:
    - postgis:db
   environment:
-     NO_DIFFS: 'true'
+     NO_DIFFS: 'false'
 import-osm-diff:
   image: "osm2vectortiles/import-osm"
   command: ./import-diff.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ import-osm:
   links:
    - postgis:db
   environment:
-     NO_DIFFS: 'false'
+     DIFFS: 'true'
 import-osm-diff:
   image: "osm2vectortiles/import-osm"
   command: ./import-diff.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,8 @@ import-osm:
    - cache
   links:
    - postgis:db
+  environment:
+     NO_DIFFS: false
 import-osm-diff:
   image: "osm2vectortiles/import-osm"
   command: ./import-diff.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ import-osm:
   links:
    - postgis:db
   environment:
-     NO_DIFFS: false
+     NO_DIFFS: 'true'
 import-osm-diff:
   image: "osm2vectortiles/import-osm"
   command: ./import-diff.sh

--- a/src/import-osm/import.sh
+++ b/src/import-osm/import.sh
@@ -7,6 +7,8 @@ readonly IMPORT_DATA_DIR=${IMPORT_DATA_DIR:-/data/import}
 readonly IMPOSM_CACHE_DIR=${IMPOSM_CACHE_DIR:-/data/cache}
 readonly MAPPING_JSON=${MAPPING_JSON:-/usr/src/app/mapping.json}
 
+readonly NO_DIFFS=${NO_DIFFS:-false}
+
 readonly OSM_DB=${OSM_DB:-osm}
 readonly OSM_USER=${OSM_USER:-osm}
 readonly OSM_PASSWORD=${OSM_PASSWORD:-osm}
@@ -26,6 +28,7 @@ function import_pbf() {
     local pbf_file="$1"
     drop_tables
     create_timestamp_history
+    if [ "$NO_DIFFS" = false ]; then
     imposm3 import \
         -connection "$PG_CONNECT" \
         -mapping "$MAPPING_YAML" \
@@ -34,6 +37,16 @@ function import_pbf() {
         -read "$pbf_file" \
         -dbschema-import="${DB_SCHEMA}" \
         -write -optimize -diff
+    else
+    imposm3 import \
+        -connection "$PG_CONNECT" \
+        -mapping "$MAPPING_YAML" \
+        -overwritecache \
+        -cachedir "$IMPOSM_CACHE_DIR" \
+        -read "$pbf_file" \
+        -dbschema-import="${DB_SCHEMA}" \
+        -write -optimize
+    fi
 
     echo "Create osm_water_point table with precalculated centroids"
     create_osm_water_point_table

--- a/src/import-osm/import.sh
+++ b/src/import-osm/import.sh
@@ -7,7 +7,7 @@ readonly IMPORT_DATA_DIR=${IMPORT_DATA_DIR:-/data/import}
 readonly IMPOSM_CACHE_DIR=${IMPOSM_CACHE_DIR:-/data/cache}
 readonly MAPPING_JSON=${MAPPING_JSON:-/usr/src/app/mapping.json}
 
-readonly NO_DIFFS=${NO_DIFFS:-false}
+readonly DIFFS=${DIFFS:-true}
 
 readonly OSM_DB=${OSM_DB:-osm}
 readonly OSM_USER=${OSM_USER:-osm}
@@ -28,7 +28,7 @@ function import_pbf() {
     local pbf_file="$1"
     drop_tables
     create_timestamp_history
-    if [ "$NO_DIFFS" = false ]; then
+    if [ "$DIFFS" = true ]; then
     echo "Importing in diff mode"
     imposm3 import \
         -connection "$PG_CONNECT" \

--- a/src/import-osm/import.sh
+++ b/src/import-osm/import.sh
@@ -29,6 +29,7 @@ function import_pbf() {
     drop_tables
     create_timestamp_history
     if [ "$NO_DIFFS" = false ]; then
+    echo "Importing in diff mode"
     imposm3 import \
         -connection "$PG_CONNECT" \
         -mapping "$MAPPING_YAML" \
@@ -38,6 +39,7 @@ function import_pbf() {
         -dbschema-import="${DB_SCHEMA}" \
         -write -optimize -diff
     else
+    echo "Importing in normal mode"
     imposm3 import \
         -connection "$PG_CONNECT" \
         -mapping "$MAPPING_YAML" \


### PR DESCRIPTION
Disabling normal-mode can save some significant time from imposm (13hrs vs 6.5hrs in one case). For some people who may not be following latest changesets (or do so irregularly where it might be best just to do a full reimport), this gives the option for a faster first import.

It defaults to DIFF-mode so it shouldn't impact most people unless they specifically want this functionality.

Tested on the Greenland extract.