### PR TITLE
Updates tilelive-tmsource package in order to support mvt v2

### DIFF
--- a/src/export/Dockerfile
+++ b/src/export/Dockerfile
@@ -9,7 +9,7 @@ RUN npm install -g \
           mapnik@3.5.x \
           mbtiles@0.8.x \
           tilelive@5.12.x \
-          tilelive-tmsource@0.4.x \
+          tilelive-tmsource@0.5.x \
           tilelive-vector@3.9.x \
           tilelive-bridge@2.3.x \
           tilelive-mapnik@0.6.x


### PR DESCRIPTION
mojodna (tilelive-tmsource maintainer) wrote:
> `tilelive-tmsource@0.5.0` now generates v2 vector tiles. Thanks @hannesj for the PR (and apologies for not merging it sooner).

The tilelive-tm2source package needs to be upgraded first in order to generate mvt v2 compatible vecor tiles.