### PR TITLE
Ack first, work second

### DIFF
--- a/src/export/export_remote.py
+++ b/src/export/export_remote.py
@@ -215,7 +215,8 @@ def export_remote(tm2source, rabbitmq_url, queue_name, result_queue_name,
             channel.stop_consuming()
             print('No message received - stop consuming')
             break
-
+          
+        channel.basic_ack(delivery_tag=method_frame.delivery_tag)
         try:
             result_msg = handle_message(
                 tm2source, bucket,
@@ -225,10 +226,9 @@ def export_remote(tm2source, rabbitmq_url, queue_name, result_queue_name,
 
             durable_publish(channel, result_queue_name,
                             body=json.dumps(result_msg))
-            channel.basic_ack(delivery_tag=method_frame.delivery_tag)
+
         except:
             durable_publish(channel, failed_queue_name, body=body)
-            channel.basic_ack(delivery_tag=method_frame.delivery_tag)
             channel.stop_consuming()
             time.sleep(5)  # Give RabbitMQ some time
             raise

--- a/src/export/export_remote.py
+++ b/src/export/export_remote.py
@@ -223,16 +223,13 @@ def export_remote(tm2source, rabbitmq_url, queue_name, result_queue_name,
                 functools.partial(s3_url, host, port, bucket_name),
                 body
             )
-
             durable_publish(channel, result_queue_name,
                             body=json.dumps(result_msg))
-
         except:
             durable_publish(channel, failed_queue_name, body=body)
             channel.stop_consuming()
             time.sleep(5)  # Give RabbitMQ some time
             raise
-
     connection.close()
 
 


### PR DESCRIPTION
This is a testing pull-request for acking first, working later.

My rationale is this: The message needs to be acknowledged regardless of whether it completes or fails. The RabbitMQ server is expecting an ack sooner rather than later. The republish to the jobs/failed-jobs queue represents the success/failure, not the ack.

If it's not acknowledged, it gets into an unacknowledged state which is difficult to re-queue. My workaround is at the end when only unacks remain, remove all connections, and restart all the workers. But that's a pain

Still testing, no rush as there's a workaround