### PR TITLE
Improved low zoom levels (show country_label earlier)

### DIFF
--- a/osm2vectortiles.tm2source/data.yml
+++ b/osm2vectortiles.tm2source/data.yml
@@ -485,17 +485,17 @@ Layer:
           coalesce(NULLIF(name_fr, ''), name) AS name_fr,
           coalesce(NULLIF(name_de, ''), name) AS name_de,
           coalesce(NULLIF(name_ru, ''), name) AS name_ru,
-          coalesce(NULLIF(name_zh, ''), name) AS name_zh, 
+          coalesce(NULLIF(name_zh, ''), name) AS name_zh,
           rank AS scalerank
           FROM custom_countries
           WHERE (
             (
-              rank <= 1
+              rank <= 2
               AND z(!scale_denominator!) = 1 AND wkb_geometry && !bbox!
             )
             OR
             (
-              rank <= 2
+              rank <= 3
               AND z(!scale_denominator!) >= 2 AND wkb_geometry && !bbox!
             )
             OR

--- a/osm2vectortiles.tm2source/data.yml
+++ b/osm2vectortiles.tm2source/data.yml
@@ -431,12 +431,8 @@ Layer:
             WHERE z(!scale_denominator!) = 0
             UNION ALL
             SELECT osm_id, geometry, admin_level, disputed, maritime
-            FROM admin_z1
-            WHERE z(!scale_denominator!) = 1
-            UNION ALL
-            SELECT osm_id, geometry, admin_level, disputed, maritime
-            FROM admin_z2
-            WHERE z(!scale_denominator!) = 2
+            FROM admin_z1toz2
+            WHERE z(!scale_denominator!) BETWEEN 1 AND 2
             UNION ALL
             SELECT osm_id, geometry, admin_level, disputed, maritime
             FROM admin_z3

--- a/src/import-sql/layers/admin.sql
+++ b/src/import-sql/layers/admin.sql
@@ -2,24 +2,12 @@ CREATE OR REPLACE VIEW admin_z0 AS
     SELECT 0 AS osm_id, geom AS geometry, 2 AS admin_level, 0 AS disputed, 0 AS maritime
     FROM ne_110m_admin_0_boundary_lines_land;
 
-CREATE OR REPLACE VIEW admin_z1 AS
+CREATE OR REPLACE VIEW admin_z1toz2 AS
     SELECT 0 AS osm_id, geom AS geometry, 2 AS admin_level, 0 AS disputed, 0 AS maritime
-    FROM ne_110m_admin_0_boundary_lines_land
+    FROM ne_50m_admin_0_boundary_lines_land
     UNION ALL
     SELECT 0 AS osm_id, geom AS geometry, 4 AS admin_level, 0 AS disputed, 0 AS maritime
     FROM ne_50m_admin_1_states_provinces_lines
-    WHERE scalerank = 2;
-
-CREATE OR REPLACE VIEW admin_z2 AS
-    SELECT 0 AS osm_id, geom AS geometry, 2 AS admin_level, 0 AS disputed, 0 AS maritime
-    FROM ne_110m_admin_0_boundary_lines_land
-    UNION ALL
-    SELECT id AS osm_id, geometry, admin_level, 0 AS disputed, maritime
-    FROM osm_admin_linestring
-    WHERE maritime = 1 AND admin_level = 2
-    UNION ALL
-    SELECT 0 AS osm_id, geom AS geometry, 4 AS admin_level, 0 AS disputed, 0 AS maritime
-    FROM ne_10m_admin_1_states_provinces_lines_shp
     WHERE scalerank = 2;
 
 CREATE OR REPLACE VIEW admin_z3 AS
@@ -69,9 +57,7 @@ CREATE OR REPLACE VIEW admin_z7toz14 AS
 CREATE OR REPLACE VIEW admin_layer AS (
     SELECT osm_id FROM admin_z0
     UNION
-    SELECT osm_id FROM admin_z1
-    UNION
-    SELECT osm_id FROM admin_z2
+    SELECT osm_id FROM admin_z1toz2
     UNION
     SELECT osm_id FROM admin_z3
     UNION


### PR DESCRIPTION
Show country labels earlier. Labels can still be filtered on client side if you want less but this provides more options.
Also some small adjustement on admin level. 50million meter Natural Earth data is now already used at z1.

On left side our old OSM Bright right one is with the applied changes.

![compare_open_streets_with_mapbox_streets](https://cloud.githubusercontent.com/assets/1288339/17620633/f799596c-608d-11e6-8056-6941d6b1e93f.png)
