### PR TITLE
Compare with our public CDN version not Mapbox

### DIFF
--- a/tools/compare-visual/index.html
+++ b/tools/compare-visual/index.html
@@ -22,7 +22,7 @@
 
 	var map1 = new mapboxgl.Map({
 			container: 'map1',
-			style: 'mapbox://styles/morgenkaffee/cimxjgllv00u69wnj7mfsgdj1',
+			style: 'https://raw.githubusercontent.com/osm2vectortiles/mapbox-gl-styles/master/styles/bright-v9-cdn.json',
 			center: zurichViewport,
       zoom: 12,
       hash: true


### PR DESCRIPTION
The compare tool now compares with the public CDN version no longer with Mapbox OSM Bright since we are moving away from that.