### PR TITLE
Contour lines

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -33,6 +33,9 @@ OSM2VectorTiles Contributors (sorted historically)
   - Integrate polygon splitting
   - Research reasons for non performant planet regions
 
+- **[Roman Shuvalov](https://github.com/romanshuvalov)**
+  - Contour lines
+
 ## Organizations
 
 - **[Klokan Technologies](https://www.klokantech.com/)**

--- a/osm2vectortiles.tm2source/data.yml
+++ b/osm2vectortiles.tm2source/data.yml
@@ -249,6 +249,49 @@ Layer:
     properties: 
       "buffer-size": 4
     srs: +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over
+  - id: contour
+    Datasource: 
+      dbname: osm
+      extent: -20037508.34,-20037508.34,20037508.34,20037508.34
+      geometry_field: geometry
+      geometry_table: ''
+      host: db
+      key_field: osm_id
+      key_field_as_attribute: false
+      max_size: 512
+      password: osm
+      port: 5432
+      srid: ''
+      table: |-
+        (
+          SELECT osm_ids2mbid(osm_id, true) AS osm_id, geometry, ele
+          FROM (
+            SELECT osm_id, geometry, ele
+            FROM contour_z8toz9
+            WHERE z(!scale_denominator!) BETWEEN 8 AND 9
+            UNION ALL
+            SELECT osm_id, geometry, ele
+            FROM contour_z10toz11
+            WHERE z(!scale_denominator!) BETWEEN 10 AND 11
+            UNION ALL
+            SELECT osm_id, geometry, ele
+            FROM contour_z12toz13
+            WHERE z(!scale_denominator!) BETWEEN 12 AND 13
+            UNION ALL
+            SELECT osm_id, geometry, ele
+            FROM contour_z14
+            WHERE z(!scale_denominator!) = 14
+          ) AS contour
+          WHERE geometry && !bbox!
+        ) AS data
+      type: postgis 
+      user: osm
+    description: ''
+    fields: 
+      ele: "Elevation in meters"
+    properties: 
+      "buffer-size": 8
+    srs: +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0.0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs +over
   - id: building
     Datasource: 
       dbname: osm
@@ -1195,3 +1238,4 @@ Layer:
 maxzoom: 14
 minzoom: 0
 name: OSM2VectorTiles v1.4
+

--- a/src/import-contour/Dockerfile
+++ b/src/import-contour/Dockerfile
@@ -1,0 +1,15 @@
+FROM mdillon/postgis:9.4
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      unzip \
+      gdal-bin \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV IMPORT_DATA_DIR=/data/import 
+VOLUME /data/import /data/cache
+
+
+COPY . /usr/src/app
+WORKDIR /usr/src/app
+
+CMD ["./import.sh"]

--- a/src/import-contour/README.md
+++ b/src/import-contour/README.md
@@ -1,0 +1,25 @@
+# import-contour
+
+The **import-external** component is responsible for importing vector contour lines into the PostGIS database.
+
+## Usage
+
+First, put contour shapefiles into *import/contour/* folder. Shapefiles must be archived to ZIP files like this:
+
+```
+import/contour/contour_N48_E8.zip
+               |- contour_N48_E8
+                  |- contour_N48_E8.dbf 
+                  |- contour_N48_E8.prj 
+                  |- contour_N48_E8.shp 
+                  |- contour_N48_E8.shx 
+```
+
+Name of folder and files and ZIP archive must be same. 
+
+To import these files run
+```
+docker-compose run import-contour
+```
+
+`import-contour` should be used before `import-sql`.  

--- a/src/import-contour/import-contour.sh
+++ b/src/import-contour/import-contour.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+set -o nounset
+
+readonly IMPORT_DATA_DIR=${IMPORT_DATA_DIR:-/data/import}
+readonly IMPORT_CONTOUR_DIR="${IMPORT_DATA_DIR}/contour"
+
+source sql.sh
+
+function import_shp() {
+	local shp_file=$1
+	local table_name=$2
+	local a_parameter=${3:-''}
+	# for WGS84 use 4326:3857
+	# for EPSG:3857 use 3857:3857
+	shp2pgsql  $a_parameter -s 3857:3857 -I -g geometry "$shp_file" "$table_name" | exec_psql | hide_inserts
+}
+
+function generalize_contour() {
+    local table=$1
+	local gen_table=$2
+	local tolerance=$3
+
+	local drop_command="DROP TABLE IF EXISTS $gen_table CASCADE;"
+	echo $drop_command | exec_psql
+
+	local gen_command="CREATE TABLE $gen_table AS SELECT id, height, ST_SimplifyPreserveTopology(geometry,$tolerance) as geometry from $table;"
+	echo $gen_command | exec_psql
+}
+
+function import_contour() {
+
+    local table_name="contour_lines"
+	local table_name_gen0=${table_name}_gen0
+	local table_name_gen1=${table_name}_gen1
+    drop_table_cascade "$table_name_gen0"
+    drop_table_cascade "$table_name_gen1"
+
+	local a_parameter=''
+
+	if [ "$(ls -A $IMPORT_CONTOUR_DIR/*.zip 2> /dev/null)" ]; then
+        local zip_file
+		local file_basename
+        for zip_file in "$IMPORT_CONTOUR_DIR"/*.zip; do
+			file_basename=`basename $zip_file .zip`
+			echo ""
+            echo "Importing $zip_file: "
+			
+			# unzipping into same import folder, probably it's better to use temp folder instead
+			unzip -q -o $zip_file -d $IMPORT_CONTOUR_DIR
+			import_shp "$IMPORT_CONTOUR_DIR/$file_basename/$file_basename.shp" $table_name $a_parameter
+			rm -r "$IMPORT_CONTOUR_DIR/$file_basename/"
+			
+			# this parameter means adding shapefile into existing table, set for every next file
+			a_parameter='-a'
+        done
+    else
+        echo "No ZIP files found in contour folder."
+        echo "Please mount the $IMPORT_CONTOUR_DIR volume to a folder containing ZIP files with contour shapefiles."
+        exit 404
+    fi
+
+	# for zoom 11 and lower
+	generalize_contour $table_name $table_name_gen0 30.0
+
+	# for zooms 13 and 12
+	generalize_contour $table_name $table_name_gen1 10.0
+
+
+}
+
+
+import_contour
+
+
+

--- a/src/import-contour/import.sh
+++ b/src/import-contour/import.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+set -o nounset
+
+function import_all() {
+    ./import-contour.sh
+}
+
+import_all

--- a/src/import-contour/sql.sh
+++ b/src/import-contour/sql.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+set -o nounset
+
+readonly DB_HOST=$DB_PORT_5432_TCP_ADDR
+readonly DB_PORT=$DB_PORT_5432_TCP_PORT
+
+readonly OSM_DB=${OSM_DB:-osm}
+readonly OSM_USER=${OSM_USER:-osm}
+readonly OSM_PASSWORD=${OSM_PASSWORD:-osm}
+
+function exec_psql() {
+    PG_PASSWORD=$OSM_PASSWORD psql --host="$DB_HOST" --port=5432 --dbname="$OSM_DB" --username="$OSM_USER"
+}
+
+function exec_sql_file() {
+	local sql_file=$1
+    cat "$sql_file" | exec_psql
+}
+
+function drop_table() {
+    local table=$1
+	local drop_command="DROP TABLE IF EXISTS $table;"
+	echo $drop_command | exec_psql
+}
+
+function drop_table_cascade() {
+    local table=$1
+	local drop_command="DROP TABLE IF EXISTS $table CASCADE;"
+	echo $drop_command | exec_psql
+}
+
+function hide_inserts() {
+    grep -v "INSERT 0 1"
+}

--- a/src/import-sql/layers/contour.sql
+++ b/src/import-sql/layers/contour.sql
@@ -1,0 +1,20 @@
+
+CREATE OR REPLACE VIEW contour_z8toz9 AS
+    SELECT id AS osm_id, height as ele, geometry
+    FROM contour_lines_gen0
+	WHERE ((cast(height as integer)%100) = 0);
+
+CREATE OR REPLACE VIEW contour_z10toz11 AS
+    SELECT id AS osm_id, height as ele, geometry
+    FROM contour_lines_gen0
+	WHERE ((cast(height as integer)%50) = 0);
+
+CREATE OR REPLACE VIEW contour_z12toz13 AS
+    SELECT id AS osm_id, height as ele, geometry
+    FROM contour_lines_gen1;
+
+CREATE OR REPLACE VIEW contour_z14 AS
+    SELECT id AS osm_id, height as ele, geometry
+    FROM contour_lines;
+
+

--- a/src/import-sql/tables.yml
+++ b/src/import-sql/tables.yml
@@ -31,6 +31,10 @@ tables:
     buffer: 2
     min_zoom: 13
     max_zoom: 14
+  contour_linestring:
+    buffer: 128
+    min_zoom: 8
+    max_zoom: 14
   housenumber_point:
     buffer: 64
     min_zoom: 14


### PR DESCRIPTION
Added `import-contour`. Note that contour lines MUST be imported, otherwise export script may fail because of absence of contour-related tables.