### PR TITLE
Using ST_Simplify on geometries for different zoom levels [DO NOT PULL YET]

### DIFF
--- a/src/import-sql/layers/landuse.sql
+++ b/src/import-sql/layers/landuse.sql
@@ -1,41 +1,48 @@
-CREATE OR REPLACE VIEW landuse_z5toz6 AS
-    SELECT id AS osm_id, geometry, type
+DROP VIEW landuse_z5toz6 CASCADE;
+CREATE VIEW landuse_z5toz6 AS
+    SELECT id AS osm_id, ST_Simplify(geometry, 2444) as geometry, type
     FROM osm_landuse_polygon_subdivided_gen0
     WHERE landuse_class(type) = 'wood'
       AND area > 10000000;
 
-CREATE OR REPLACE VIEW landuse_z7toz8 AS
-    SELECT id AS osm_id, geometry, type
+DROP VIEW landuse_z7toz8 CASCADE;
+CREATE VIEW landuse_z7toz8 AS
+    SELECT id AS osm_id, ST_Simplify(geometry, 500) as geometry, type
     FROM osm_landuse_polygon_subdivided_gen0
     WHERE landuse_class(type) IN ('wood', 'residential')
       AND area > 1000000;
 
-CREATE OR REPLACE VIEW landuse_z9 AS
-    SELECT id AS osm_id, geometry, type
+DROP VIEW landuse_z9 CASCADE;
+CREATE VIEW landuse_z9 AS
+    SELECT id AS osm_id, ST_Simplify(geometry, 200) as geometry, type
     FROM osm_landuse_polygon_subdivided_gen0
     WHERE landuse_class(type) IN ('wood', 'residential', 'grass', 'cemetery', 'park', 'school')
       AND area > 500000;
 
-CREATE OR REPLACE VIEW landuse_z10 AS
-    SELECT id AS osm_id, geometry, type
+DROP VIEW landuse_z10 CASCADE;
+CREATE VIEW landuse_z10 AS
+    SELECT id AS osm_id, ST_Simplify(geometry, 77) as geometry, type
     FROM osm_landuse_polygon_subdivided_gen0
     WHERE landuse_class(type) IN ('wood', 'residential', 'commercial', 'retail', 'railway', 'industrial', 'grass', 'cemetery', 'park', 'school')
       AND area > 99000;
 
-CREATE OR REPLACE VIEW landuse_z11 AS
-    SELECT id AS osm_id, geometry, type
+DROP VIEW landuse_z11 CASCADE;
+CREATE VIEW landuse_z11 AS
+    SELECT id AS osm_id, ST_Simplify(geometry, 38) as geometry, type
     FROM osm_landuse_polygon_subdivided_gen1
     WHERE landuse_class(type) IN ('wood', 'residential','commercial', 'retail', 'railway', 'industrial', 'military', 'grass', 'cemetery', 'park', 'school', 'hospital')
       AND area > 50000;
 
-CREATE OR REPLACE VIEW landuse_z12 AS
-    SELECT id AS osm_id, geometry, type
+DROP VIEW landuse_z12 CASCADE;
+CREATE VIEW landuse_z12 AS
+    SELECT id AS osm_id, ST_Simplify(geometry, 19) as geometry, type
     FROM osm_landuse_polygon_subdivided
     WHERE landuse_class(type) IN ('wood', 'residential', 'grass','retail', 'railway', 'industrial', 'military', 'cemetery', 'park', 'school', 'hospital')
       AND area > 10000;
 
-CREATE OR REPLACE VIEW landuse_z13toz14 AS
-    SELECT id AS osm_id, geometry, type
+DROP VIEW landuse_z13toz14 CASCADE;
+CREATE VIEW landuse_z13toz14 AS
+    SELECT id AS osm_id, ST_Simplify(geometry, 0.1) as geometry, type
     FROM osm_landuse_polygon_subdivided
     WHERE type NOT IN ('wetland', 'marsh', 'swamp', 'bog', 'mud', 'tidalflat', 'national_park', 'nature_reserve', 'protected_area');
 

--- a/src/import-sql/layers/landuse_overlay.sql
+++ b/src/import-sql/layers/landuse_overlay.sql
@@ -5,43 +5,51 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE OR REPLACE VIEW landuse_overlay_z5 AS
-    SELECT id AS osm_id, type, geometry
+DROP VIEW landuse_overlay_z5 CASCADE;
+CREATE VIEW landuse_overlay_z5 AS
+    SELECT id AS osm_id, type, ST_Simplify(geometry, 2444) as geometry
     FROM osm_landuse_polygon_subdivided_gen0
     WHERE is_landuse_overlay(type) AND area > 300000000;
 
-CREATE OR REPLACE VIEW landuse_overlay_z6 AS
-    SELECT id AS osm_id, type, geometry
+DROP VIEW landuse_overlay_z6 CASCADE;
+CREATE VIEW landuse_overlay_z6 AS
+    SELECT id AS osm_id, type, ST_Simplify(geometry, 1222) as geometry
     FROM osm_landuse_polygon_subdivided_gen0
     WHERE is_landuse_overlay(type) AND area > 100000000;
 
-CREATE OR REPLACE VIEW landuse_overlay_z7 AS
-    SELECT id AS osm_id, type, geometry
+DROP VIEW landuse_overlay_z7 CASCADE;
+CREATE VIEW landuse_overlay_z7 AS
+    SELECT id AS osm_id, type, ST_Simplify(geometry, 611) as geometry
     FROM osm_landuse_polygon_subdivided_gen0
     WHERE is_landuse_overlay(type) AND area > 20000000;
 
-CREATE OR REPLACE VIEW landuse_overlay_z8 AS
-    SELECT id AS osm_id, type, geometry
+DROP VIEW landuse_overlay_z8 CASCADE;
+CREATE VIEW landuse_overlay_z8 AS
+    SELECT id AS osm_id, type, ST_Simplify(geometry, 305) as geometry
     FROM osm_landuse_polygon_subdivided_gen0
     WHERE is_landuse_overlay(type) AND area > 6000000;
 
-CREATE OR REPLACE VIEW landuse_overlay_z9 AS
-    SELECT id AS osm_id, type, geometry
+DROP VIEW landuse_overlay_z9 CASCADE;
+CREATE VIEW landuse_overlay_z9 AS
+    SELECT id AS osm_id, type, ST_Simplify(geometry, 152) as geometry
     FROM osm_landuse_polygon_subdivided_gen0
     WHERE is_landuse_overlay(type) AND area > 2000000;
 
-CREATE OR REPLACE VIEW landuse_overlay_z10 AS
-    SELECT id AS osm_id, type, geometry
+DROP VIEW landuse_overlay_z10 CASCADE;
+CREATE VIEW landuse_overlay_z10 AS
+    SELECT id AS osm_id, type, ST_Simplify(geometry, 76) as geometry
     FROM osm_landuse_polygon_subdivided_gen0
     WHERE is_landuse_overlay(type) AND area > 500000;
 
-CREATE OR REPLACE VIEW landuse_overlay_z11toz12 AS
-    SELECT id AS osm_id, type, geometry
+DROP VIEW landuse_overlay_z11toz12 CASCADE;
+CREATE VIEW landuse_overlay_z11toz12 AS
+    SELECT id AS osm_id, type, ST_Simplify(geometry, 30) as geometry
     FROM osm_landuse_polygon_subdivided_gen1
     WHERE is_landuse_overlay(type);
 
-CREATE OR REPLACE VIEW landuse_overlay_z13toz14 AS
-    SELECT id AS osm_id, type, geometry
+DROP VIEW landuse_overlay_z13toz14 CASCADE;
+CREATE VIEW landuse_overlay_z13toz14 AS
+    SELECT id AS osm_id, type, ST_Simplify(geometry, 0.1) as geometry
     FROM osm_landuse_polygon_subdivided
     WHERE is_landuse_overlay(type);
 

--- a/src/import-sql/layers/road.sql
+++ b/src/import-sql/layers/road.sql
@@ -24,43 +24,51 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
-CREATE OR REPLACE VIEW road_z5 AS
-    SELECT id AS osm_id, geometry, type, construction, tracktype, service, access, oneway, 'none'::varchar(4) AS structure, z_order
+DROP VIEW road_z5 CASCADE;
+CREATE VIEW road_z5 AS
+    SELECT id AS osm_id, ST_Simplify(geometry, 2444) as geometry, type, construction, tracktype, service, access, oneway, 'none'::varchar(4) AS structure, z_order
     FROM osm_road_geometry
     WHERE road_class(type, service, access) IN ('motorway', 'trunk');
 
-CREATE OR REPLACE VIEW road_z6toz7 AS
-    SELECT id AS osm_id, geometry, type, construction, tracktype, service, access, oneway, 'none'::varchar(4) AS structure, z_order
+DROP VIEW road_z6toz7 CASCADE;
+CREATE VIEW road_z6toz7 AS
+    SELECT id AS osm_id, ST_Simplify(geometry, 916) as geometry, type, construction, tracktype, service, access, oneway, 'none'::varchar(4) AS structure, z_order
     FROM osm_road_geometry
     WHERE road_class(type, service, access) IN ('motorway', 'trunk', 'primary');
 
-CREATE OR REPLACE VIEW road_z8toz9 AS
-    SELECT id AS osm_id, geometry, type, construction, tracktype, service, access, oneway, 'none'::varchar(4) AS structure, z_order
+DROP VIEW road_z8toz9 CASCADE;
+CREATE VIEW road_z8toz9 AS
+    SELECT id AS osm_id, ST_Simplify(geometry, 229) as geometry, type, construction, tracktype, service, access, oneway, 'none'::varchar(4) AS structure, z_order
     FROM osm_road_geometry
     WHERE road_class(type, service, access) IN ('motorway', 'motorway_link', 'trunk', 'primary', 'secondary', 'major_rail');
 
-CREATE OR REPLACE VIEW road_z10 AS
-    SELECT id AS osm_id, geometry, type, construction, tracktype, service, access, oneway, 'none'::varchar(4) AS structure, z_order
+DROP VIEW road_z10 CASCADE;
+CREATE VIEW road_z10 AS
+    SELECT id AS osm_id, ST_Simplify(geometry, 77) as geometry, type, construction, tracktype, service, access, oneway, 'none'::varchar(4) AS structure, z_order
     FROM osm_road_geometry
     WHERE road_class(type, service, access) IN ('motorway', 'motorway_link', 'trunk', 'primary', 'secondary', 'tertiary', 'major_rail');
 
-CREATE OR REPLACE VIEW road_z11 AS
-    SELECT id AS osm_id, geometry, type, construction, tracktype, service, access, oneway, 'none'::varchar(4) AS structure, z_order
+DROP VIEW road_z11 CASCADE;
+CREATE VIEW road_z11 AS
+    SELECT id AS osm_id, ST_Simplify(geometry, 38) as geometry, type, construction, tracktype, service, access, oneway, 'none'::varchar(4) AS structure, z_order
     FROM osm_road_geometry
     WHERE road_class(type, service, access) IN ('motorway', 'motorway_link', 'trunk', 'primary', 'secondary', 'tertiary', 'major_rail', 'street', 'ferry');
 
-CREATE OR REPLACE VIEW road_z12 AS
-    SELECT id AS osm_id, geometry, type, construction, tracktype, service, access, oneway, 'none'::varchar(4) AS structure, z_order
+DROP VIEW road_z12 CASCADE;
+CREATE VIEW road_z12 AS
+    SELECT id AS osm_id, ST_Simplify(geometry, 19) as geometry, type, construction, tracktype, service, access, oneway, 'none'::varchar(4) AS structure, z_order
     FROM osm_road_geometry
     WHERE road_type_class(type) IN ('motorway', 'motorway_link', 'trunk', 'primary', 'secondary', 'tertiary', 'major_rail', 'street', 'ferry', 'pedestrian', 'service', 'link', 'construction', 'street_limited', 'aerialway');
 
-CREATE OR REPLACE VIEW road_z13 AS
-    SELECT id AS osm_id, geometry, type, construction, tracktype, service, access, oneway, road_structure(is_tunnel, is_bridge, is_ford) AS structure, z_order
+DROP VIEW road_z13 CASCADE;
+CREATE VIEW road_z13 AS
+    SELECT id AS osm_id, ST_Simplify(geometry, 9) as geometry, type, construction, tracktype, service, access, oneway, road_structure(is_tunnel, is_bridge, is_ford) AS structure, z_order
     FROM osm_road_geometry
     WHERE road_type_class(type) IN ('motorway', 'motorway_link', 'trunk', 'primary', 'secondary', 'tertiary', 'major_rail', 'street', 'ferry', 'pedestrian', 'service', 'link', 'construction', 'street_limited', 'aerialway', 'track');
 
-CREATE OR REPLACE VIEW road_z14 AS
-    SELECT id AS osm_id, geometry, type, construction, tracktype, service, access, oneway, road_structure(is_tunnel, is_bridge, is_ford) AS structure, z_order
+DROP VIEW road_z14 CASCADE;
+CREATE VIEW road_z14 AS
+    SELECT id AS osm_id, ST_Simplify(geometry, 0.1) as geometry, type, construction, tracktype, service, access, oneway, road_structure(is_tunnel, is_bridge, is_ford) AS structure, z_order
     FROM osm_road_geometry;
 
 CREATE OR REPLACE VIEW road_layer AS (

--- a/src/import-sql/layers/water.sql
+++ b/src/import-sql/layers/water.sql
@@ -1,54 +1,62 @@
-CREATE OR REPLACE VIEW water_z0 AS
-    SELECT 0 AS osm_id, geometry
+DROP VIEW water_z0 CASCADE;
+CREATE VIEW water_z0 AS
+    SELECT 0 AS osm_id, ST_Simplify(geometry, 2444) as geometry
     FROM osm_ocean_polygon_gen0
     UNION ALL
-    SELECT 0 AS osm_id, geom AS geometry
+    SELECT 0 AS osm_id, ST_Simplify(geom, 2444) AS geometry
     FROM ne_110m_lakes;
 
-CREATE OR REPLACE VIEW water_z1 AS
-    SELECT 0 AS osm_id, geometry
+DROP VIEW water_z1 CASCADE;
+CREATE VIEW water_z1 AS
+    SELECT 0 AS osm_id, ST_Simplify(geometry, 2444) as geometry
     FROM osm_ocean_polygon_gen0
     UNION ALL
-    SELECT 0 AS osm_id, geom AS geometry
+    SELECT 0 AS osm_id, ST_Simplify(geom, 2444) AS geometry
     FROM ne_110m_lakes;
 
-CREATE OR REPLACE VIEW water_z2toz3 AS
-    SELECT 0 AS osm_id, geometry
+DROP VIEW water_z2toz3 CASCADE;
+CREATE VIEW water_z2toz3 AS
+    SELECT 0 AS osm_id, ST_Simplify(geometry, 2444) as geometry
     FROM osm_ocean_polygon_gen1
     UNION ALL
-    SELECT 0 AS osm_id, geom AS geometry
+    SELECT 0 AS osm_id, ST_Simplify(geom, 2444) AS geometry
     FROM ne_50m_lakes;
 
-CREATE OR REPLACE VIEW water_z4 AS
-    SELECT 0 AS osm_id, geometry
+DROP VIEW water_z4 CASCADE;
+CREATE VIEW water_z4 AS
+    SELECT 0 AS osm_id, ST_Simplify(geometry, 2444) as geometry
     FROM osm_ocean_polygon_gen1
     UNION ALL
-    SELECT 0 AS osm_id, geom AS geometry
+    SELECT 0 AS osm_id, ST_Simplify(geom, 2444) AS geometry
     FROM ne_10m_lakes;
 
-CREATE OR REPLACE VIEW water_z5toz7 AS
-    SELECT 0 AS osm_id, geometry
+DROP VIEW water_z5toz7 CASCADE;
+CREATE VIEW water_z5toz7 AS
+    SELECT 0 AS osm_id, ST_Simplify(geometry, 916) as geometry
     FROM osm_ocean_polygon_gen1
     UNION ALL
-    SELECT id AS osm_id, geometry
+    SELECT id AS osm_id, ST_Simplify(geometry, 916) as geometry
     FROM osm_water_polygon_gen0;
 
-CREATE OR REPLACE VIEW water_z8toz10 AS
-    SELECT 0 AS osm_id, geometry
+DROP VIEW water_z8toz10 CASCADE;
+CREATE VIEW water_z8toz10 AS
+    SELECT 0 AS osm_id, ST_Simplify(geometry, 229) as geometry
     FROM osm_ocean_polygon
     UNION ALL
-    SELECT id AS osm_id, geometry
+    SELECT id AS osm_id, ST_Simplify(geometry, 229) as geometry
     FROM osm_water_polygon_gen0;
 
-CREATE OR REPLACE VIEW water_z11toz12 AS
-    SELECT 0 AS osm_id, geometry, 0 AS area
+DROP VIEW water_z11toz12 CASCADE;
+CREATE VIEW water_z11toz12 AS
+    SELECT 0 AS osm_id, ST_Simplify(geometry, 38) as geometry, 0 AS area
     FROM osm_ocean_polygon
     UNION ALL
-    SELECT id AS osm_id, geometry, area
+    SELECT id AS osm_id, ST_Simplify(geometry, 38) as geometry, area
     FROM osm_water_polygon
     WHERE area >= 15000;
 
-CREATE OR REPLACE VIEW water_z13toz14 AS
+DROP VIEW water_z13toz14 CASCADE;
+CREATE VIEW water_z13toz14 AS
     SELECT 0 AS osm_id, geometry
     FROM osm_ocean_polygon
     UNION ALL

--- a/src/import-sql/layers/waterway.sql
+++ b/src/import-sql/layers/waterway.sql
@@ -1,20 +1,24 @@
-CREATE OR REPLACE VIEW waterway_z7toz9 AS
-    SELECT id AS osm_id, name, name_fr, name_en, name_de, name_es, name_ru, name_zh, type, geometry    
+DROP VIEW waterway_z7toz9 CASCADE;
+CREATE VIEW waterway_z7toz9 AS
+    SELECT id AS osm_id, name, name_fr, name_en, name_de, name_es, name_ru, name_zh, type, ST_Simplify(geometry, 305) as geometry
     FROM osm_water_linestring
     WHERE type = 'river';
 
-CREATE OR REPLACE VIEW waterway_z10toz12 AS
-    SELECT id AS osm_id, name, name_fr, name_en, name_de, name_es, name_ru, name_zh, type, geometry
+DROP VIEW waterway_z10toz12 CASCADE;
+CREATE VIEW waterway_z10toz12 AS
+    SELECT id AS osm_id, name, name_fr, name_en, name_de, name_es, name_ru, name_zh, type, ST_Simplify(geometry, 38) as geometry
     FROM osm_water_linestring
     WHERE type IN ('river', 'canal');
 
-CREATE OR REPLACE VIEW waterway_z13 AS
-    SELECT id AS osm_id, name, name_fr, name_en, name_de, name_es, name_ru, name_zh, type, geometry
+DROP VIEW waterway_z13 CASCADE;
+CREATE VIEW waterway_z13 AS
+    SELECT id AS osm_id, name, name_fr, name_en, name_de, name_es, name_ru, name_zh, type, ST_Simplify(geometry, 9) as geometry
     FROM osm_water_linestring
     WHERE type IN ('river', 'canal', 'stream', 'drain');
 
-CREATE OR REPLACE VIEW waterway_z14 AS
-    SELECT id AS osm_id, name, name_fr, name_en, name_de, name_es, name_ru, name_zh, type, geometry
+DROP VIEW waterway_z14 CASCADE;
+CREATE VIEW waterway_z14 AS
+    SELECT id AS osm_id, name, name_fr, name_en, name_de, name_es, name_ru, name_zh, type, ST_Simplify(geometry, 0.1) as geometry
     FROM osm_water_linestring;
 
 CREATE OR REPLACE VIEW waterway_layer AS (


### PR DESCRIPTION
I added ST_Simplify to a lot of stuff

Continuing from https://github.com/osm2vectortiles/osm2vectortiles/issues/439

- Used `DROP VIEW CASCADE / CREATE VIEW` vs `CREATE OR REPLACE VIEW` because the type returned from `ST_Simplify` is different and the view cannot be replaced.
- Added "half" of the m/pixel from this table here: http://wiki.openstreetmap.org/wiki/Zoom_levels
  - Used average on views that include a range of zoom levels, e.g. `z5toz6`
 - Used 0.1 on zoom level 14 (wanted to keep as much detail as possible, should probably remove the ST_Simplify all together, but used this approach to be sure that a type mismatch would not occur, will try to get rid of those)
  - **NOTE: didn't set the correct tolerance for ST_Simplify everywhere yet**

It is noticeably slower, but got the filesize for `zurich.mbtiles` down from **44.7mb** to **37.7mb**

Will keep working on this some more and will try to render the full planet after that.